### PR TITLE
fix(kn-next): patch Turbopack instrumentation chunks & gsutil expansion

### DIFF
--- a/packages/kn-next/src/cli/deploy.ts
+++ b/packages/kn-next/src/cli/deploy.ts
@@ -239,7 +239,8 @@ async function patchStandaloneOutput(appDir: string): Promise<void> {
   const srcChunksDir = join(appDir, '.next', 'server', 'chunks');
   if (existsSync(srcChunksDir)) {
     try {
-      const destDirs = await $`find ${serverFunctionsDir} -type d -path "*/.next/server/chunks"`.text();
+      const destDirs =
+        await $`find ${serverFunctionsDir} -type d -path "*/.next/server/chunks"`.text();
       const targetDirs = destDirs.trim().split('\n').filter(Boolean);
 
       for (const targetDir of targetDirs) {
@@ -247,7 +248,7 @@ async function patchStandaloneOutput(appDir: string): Promise<void> {
         await $`cp -n ${srcChunksDir}/*instrumentation* ${targetDir}/ 2>/dev/null || true`.quiet();
       }
       console.info('   🔧 Synced missing Turbopack instrumentation chunks to standalone output');
-    } catch { }
+    } catch {}
   }
 }
 

--- a/packages/kn-next/src/utils/asset-upload.ts
+++ b/packages/kn-next/src/utils/asset-upload.ts
@@ -51,7 +51,7 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
 
       // Post-upload verification: ensure all local files exist in GCS
       const localFiles = collectFiles(assetsDir, assetsDir);
-      const gcsListResult = await $`gsutil ls -r gs://${config.storage.bucket}/**`.text();
+      const gcsListResult = await $`gsutil ls -r "gs://${config.storage.bucket}/"`.text();
       const gcsFiles = new Set(
         gcsListResult
           .split('\n')


### PR DESCRIPTION
## Description
Fixes a crash in the OpenNext container startup when OpenTelemetry `instrumentation.ts` is enabled. 
Next.js standalone tracing drops Turbopack's dynamic server chunks, so this PR patches `kn-next deploy` to manually sync `[root-of-the-server]` chunks into the `.open-next` bundle.

Also fixes a deployment failure where `gsutil ls -r gs://bucket/**` triggered an unquoted glob expansion error in the bun shell.