### PR TITLE
ADR-0001: Embed-manifest strategy for Next.js dynamic chunks

### DIFF
--- a/docs/adr/0001-embed-manifest-strategy.md
+++ b/docs/adr/0001-embed-manifest-strategy.md
@@ -1,0 +1,30 @@
+# ADR 0001: Embed Manifest Strategy
+
+## Background
+Next.js standalone output relies on several manifest files (e.g., `server-reference-manifest.json`, `middleware-manifest.json`, etc.) being present on the file system. When bundling with Bun, we need a reliable way to ensure these files are available to the bundled code at runtime, especially when running from a single binary.
+
+## Options
+
+### Option A: NFT-Driven Generator Script
+Use the Next.js `required-server-files.json` and the output of `@vercel/nft` (Node File Trace) to identify all necessary manifest files. A generator script then creates a TypeScript file that imports these JSON files using Bun's `with { type: "file" }` syntax.
+
+### Option B: Manual Static Embedding
+Manually list known manifest files in the build configuration and use Bun's copy-file or embedding features.
+
+### Option C: Dynamic File System Access
+Rely on the files being present in a specific location on the host file system and access them using standard `fs` modules at runtime.
+
+## Decision
+**Option A: NFT-Driven Generator Script**
+
+## Rationale
+Spike #12 proved that `with { type: "file" }` imports allow embedding files into the binary VFS (`$bunfs`) and satisfying `require()` calls at runtime. This is the most deterministic approach for Next.js standalone output as it leverages Next.js's own tracing logic to ensure all required assets are included in the bundle and accessible via the virtual file system.
+
+## Consequences
+- Requires a generator script in the build pipeline to scan the standalone output and produce the embedding TypeScript file.
+- Increases the size of the final binary as all manifests are embedded.
+- Simplifies deployment as the binary becomes truly self-contained regarding its internal Next.js dependencies.
+
+## Revisit triggers
+- If Bun introduces native, built-in support for Next.js standalone output that handles manifest embedding automatically.
+- Significant changes in Next.js's standalone output structure that make NFT-based tracing unreliable.

--- a/docs/adr/0001-embed-manifest-strategy.md
+++ b/docs/adr/0001-embed-manifest-strategy.md
@@ -18,7 +18,7 @@ Rely on the files being present in a specific location on the host file system a
 **Option A: NFT-Driven Generator Script**
 
 ## Rationale
-Spike #12 proved that `with { type: "file" }` imports allow embedding files into the binary VFS (`$bunfs`) and satisfying `require()` calls at runtime. This is the most deterministic approach for Next.js standalone output as it leverages Next.js's own tracing logic to ensure all required assets are included in the bundle and accessible via the virtual file system.
+[Spike #12][spike-12] proved that `with { type: "file" }` imports allow embedding files into the binary VFS (`$bunfs`) and satisfying `require()` calls at runtime. This is the most deterministic approach for Next.js standalone output as it leverages Next.js's own tracing logic to ensure all required assets are included in the bundle and accessible via the virtual file system.
 
 ## Consequences
 - Requires a generator script in the build pipeline to scan the standalone output and produce the embedding TypeScript file.
@@ -28,3 +28,11 @@ Spike #12 proved that `with { type: "file" }` imports allow embedding files into
 ## Revisit triggers
 - If Bun introduces native, built-in support for Next.js standalone output that handles manifest embedding automatically.
 - Significant changes in Next.js's standalone output structure that make NFT-based tracing unreliable.
+
+## References
+- [Spike #12][spike-12] — Empirical proof of `next build` standalone → `bun --compile --bytecode` pipeline; full report at `docs/spikes/0001-bun-bytecode-pipeline.md`.
+- [`@vercel/nft`](https://github.com/vercel/nft) — Node File Trace, the Vercel-maintained dependency tracer used to enumerate the standalone output's runtime files.
+- [Bun `--compile` documentation](https://bun.sh/docs/bundler/executables) — Bun's single-executable compilation and bytecode flags.
+- [Next.js standalone output](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) — `output: 'standalone'` configuration.
+
+[spike-12]: https://github.com/AhmedElBanna80/knext/issues/12


### PR DESCRIPTION
## Summary

Adds ADR-0001 documenting the chosen strategy for embedding Next.js dynamic chunks into a Bun-compiled binary.

**Decision**: Option A — NFT-driven generator script. Use `@vercel/nft` to trace `.next/standalone/server.js` dependencies; generate a TypeScript embed-manifest with explicit `import` statements (and `with { type: 'file' }` for non-JS configs); feed that to `bun build --bundle` then `bun build --compile --bytecode`.

**Rationale**: Spike #12 empirically validated that `with { type: 'file' }` imports satisfy Next.js's dynamic `require()` calls via Bun's virtual filesystem (`$bunfs`). NFT is Vercel-maintained, deterministic, and matches our existing `docs/knowledge/bun-bytecode-strategy.md`.

**Rejected**: Option B (manual list — brittle), Option C (dynamic fs access — defeats single-binary goal).

**Revisit triggers**: Bun introducing native Next.js standalone support; major changes to Next standalone layout.

Closes #13.

## Test plan

- [ ] CodeRabbit review passes
- [ ] ADR content matches the approved decision in issue #13 review comment
- [ ] No unrelated changes in the diff

🤖 Subagent-driven development workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an ADR; no runtime code, build logic, or configuration is modified.
> 
> **Overview**
> Adds **ADR 0001** describing the chosen approach for making Next.js standalone manifest files available when bundling into a single Bun-compiled binary.
> 
> The ADR evaluates options and records the decision to use an `@vercel/nft`-driven generator that emits a TypeScript embed file using Bun `with { type: "file" }` imports, with noted consequences and revisit triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff7331b88d7dc1549652940d846c4962d1d8f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->