### PR TITLE
feat(16): drop Vite dev server, use next dev (Turbopack)

### DIFF
--- a/apps/file-manager/package.json
+++ b/apps/file-manager/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "next dev",
     "build": "NITRO_PRESET=bun vite build",
     "start": "node .output/server/index.mjs"
   },
@@ -28,7 +28,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "vinext": "^0.0.19",
-    "vite": "^7.3.1",
     "nitro": "3.0.1-alpha.2"
   },
   "devDependencies": {
@@ -37,7 +36,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@vitejs/plugin-rsc": "^0.5.21",
     "react-server-dom-webpack": "^19.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## Summary

Implements the decision from issue #16: drop Vite-based dev loop, standardize on `next dev` (Turbopack).

**Changes**:
- `apps/file-manager/package.json`: `"dev": "vite dev"` → `"dev": "next dev"`
- Drop `vite` dependency
- Drop `@vitejs/plugin-rsc` devDependency

**What stays (deferred to later issues)**:
- `vinext`, `nitro`, `react-server-dom-webpack` — removed as part of #17 (build config rewrite)

**Rationale**: Vite was carried only for HMR speed under vinext. Now that the migration drops vinext, Turbopack-backed `next dev` is the supported path with full App Router parity. Eliminates a dev-only experimental dependency from the supply chain.

**Note on ADR coverage**: The original branch included an ADR-0001 modification, but ADR-0001 is now owned by PR #25 (issue #13). To avoid a merge conflict, this PR is package.json-only. The dev-workflow rationale will be captured in `BUILD_PIPELINE.md` during the docs phase (#24).

Closes #16.

## Test plan

- [ ] CodeRabbit review passes
- [ ] `pnpm install` succeeds with the new lockfile
- [ ] `pnpm --filter file-manager dev` runs `next dev` on port 3000 (manual smoke after merge)
- [ ] No remaining `vite` or `@vitejs/plugin-rsc` references in `apps/file-manager/package.json`

🤖 Subagent-driven development workflow.