### PR TITLE
Complete vinext→official Next.js adapter migration (Node + NODE_COMPILE_CACHE bytecode)

### DIFF
--- a/apps/file-manager/Dockerfile
+++ b/apps/file-manager/Dockerfile
@@ -1,4 +1,4 @@
-# Stage 1: Build Vinext app with Node + pnpm
+# Stage 1: Build Next.js app with standalone output
 FROM node:22-alpine AS builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -6,42 +6,38 @@ RUN npm install -g pnpm
 WORKDIR /app
 COPY . .
 RUN pnpm install --frozen-lockfile
-RUN NITRO_PRESET=bun pnpm --filter file-manager build
+# next build → .next/standalone/ (output:'standalone' set in next.config.ts)
+RUN pnpm --filter file-manager build
 
-# Stage 2: Compile executable using Bun named image (latest 1.x version)
-FROM oven/bun:1.3.10-alpine AS compiler
+# Stage 2: Lean production image using Node.js standalone output
+FROM node:22-alpine AS runner
 WORKDIR /app
-COPY --from=builder /app /app
-WORKDIR /app/apps/file-manager
-# We compile to linux-x64-musl since we'll run on Alpine
-RUN bun build --compile --minify --bytecode --target=bun-linux-x64-musl .output/server/index.mjs --outfile file-manager-server
-
-# Stage 3: Final runner stage using pure alpine
-FROM alpine:latest AS runner
-WORKDIR /app/apps/file-manager
 ENV NODE_ENV=production
 ENV PORT=3000
 
-# Install required network tools and C++ standard libraries needed by the compiled bun executable
-RUN apk add --no-cache ca-certificates wget libstdc++ libgcc
+# Install curl for healthcheck
+RUN apk add --no-cache curl
 
-# Create node user and group
+# Create non-root user
 RUN addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node
 
-# Pre-create the Next.js cache directory to avoid permission issues
-RUN mkdir -p .next/cache .next/server && chown -R node:node .next
+# Copy standalone server bundle (includes node_modules trace)
+COPY --from=builder /app/apps/file-manager/.next/standalone ./
+# Copy static assets served locally (non-CDN fallback)
+COPY --from=builder /app/apps/file-manager/.next/static ./apps/file-manager/.next/static
+# Copy public assets
+COPY --from=builder /app/apps/file-manager/public ./apps/file-manager/public
 
-# Copy the compiled executable and public assets from compiler
-COPY --from=compiler /app/apps/file-manager/file-manager-server ./file-manager-server
-COPY --from=compiler /app/apps/file-manager/.output/public ./.output/public
+# Pre-create the compile-cache directory
+RUN mkdir -p apps/file-manager/.next/compile-cache && chown -R node:node apps/file-manager/.next
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Drop privileges
 USER node
 
-# Run the single binary executable
-CMD ["./file-manager-server"]
+# NODE_COMPILE_CACHE: V8 bytecode cache for faster subsequent cold starts
+CMD ["sh", "-c", "NODE_COMPILE_CACHE=apps/file-manager/.next/compile-cache node apps/file-manager/server.js"]

--- a/apps/file-manager/Dockerfile
+++ b/apps/file-manager/Dockerfile
@@ -39,5 +39,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 # Drop privileges
 USER node
 
-# NODE_COMPILE_CACHE: V8 bytecode cache for faster subsequent cold starts
-CMD ["sh", "-c", "NODE_COMPILE_CACHE=apps/file-manager/.next/compile-cache node apps/file-manager/server.js"]
+# NODE_COMPILE_CACHE: V8 bytecode cache for faster subsequent cold starts.
+# Use shell assignment idiom so the operator's externally-injected value (PVC path) wins;
+# the Dockerfile only supplies the fallback when the env var is unset at runtime.
+CMD ["sh", "-c", ": \"${NODE_COMPILE_CACHE:=apps/file-manager/.next/compile-cache}\"; exec node apps/file-manager/server.js"]

--- a/apps/file-manager/Dockerfile
+++ b/apps/file-manager/Dockerfile
@@ -40,6 +40,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 USER node
 
 # NODE_COMPILE_CACHE: V8 bytecode cache for faster subsequent cold starts.
-# Use shell assignment idiom so the operator's externally-injected value (PVC path) wins;
-# the Dockerfile only supplies the fallback when the env var is unset at runtime.
-CMD ["sh", "-c", ": \"${NODE_COMPILE_CACHE:=apps/file-manager/.next/compile-cache}\"; exec node apps/file-manager/server.js"]
+# EXPORT so the value reaches the exec'd node process (a bare `${VAR:=default}` only sets a shell
+# variable, not an env var). The operator's externally-injected value (PVC path) still wins via
+# `:-`; the Dockerfile only supplies the fallback when the env var is unset at runtime.
+CMD ["sh", "-c", "export NODE_COMPILE_CACHE=\"${NODE_COMPILE_CACHE:-apps/file-manager/.next/compile-cache}\"; exec node apps/file-manager/server.js"]

--- a/apps/file-manager/Dockerfile
+++ b/apps/file-manager/Dockerfile
@@ -18,8 +18,8 @@ ENV PORT=3000
 # Install curl for healthcheck
 RUN apk add --no-cache curl
 
-# Create non-root user
-RUN addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node
+# node:22-alpine already ships a non-root `node` user/group at uid/gid 1000;
+# recreating it fails ("group 'node' in use"). Reuse the existing user.
 
 # Copy standalone server bundle (includes node_modules trace)
 COPY --from=builder /app/apps/file-manager/.next/standalone ./

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This framework enables deploying Next.js applications as Knative services on GKE with Fluid Compute characteristics. It uses **Vinext** to compile Next.js into a standalone server compatible with containerized environments, while providing pluggable adapters for storage, caching, and messaging.
+This framework enables deploying Next.js applications as Knative services on GKE with Fluid Compute characteristics. It uses the **official Next.js Deployment Adapter API** (`experimental.adapterPath`) with `output:'standalone'` to produce a self-contained Node.js server, while providing pluggable adapters for storage, caching, and messaging.
 
 ## System Architecture
 
@@ -20,7 +20,7 @@ flowchart TB
     end
     
     subgraph GCP["Google Cloud Platform"]
-        GCS["Cloud Storage<br/>Static Assets + ISR Cache"]
+        GCS["Cloud Storage<br/>Static Assets"]
         AR["Artifact Registry<br/>Container Images"]
     end
     
@@ -37,18 +37,20 @@ flowchart TB
 
 ## Key Components
 
-### 1. Vinext Integration
+### 1. Official Next.js Adapter (`output:'standalone'`)
 
-Vinext transforms Next.js build output into a serverless-compatible format:
+`next build` with `output:'standalone'` and `experimental.adapterPath` produces:
 
 ```text
-├── assets/                  # Static files → GCS
-│   ├── BUILD_ID             # Unique build identifier
-│   └── _next/static/        # JS, CSS, fonts
-├── server-functions/
-│   └── default/             # Node.js server → Docker image
-└── cache/                   # Pre-rendered pages
+.next/
+├── standalone/          # Self-contained Node.js server (copied to Docker image)
+│   └── server.js        # Entry point — starts the Next.js HTTP server
+├── static/              # Client-side JS/CSS/fonts → uploaded to GCS
+└── cache/               # Build-time pre-rendered pages
 ```
+
+The `next-adapter.ts` (`NextAdapter`) hooks into `modifyConfig` (enforce standalone) and
+`onBuildComplete` (upload static assets to object storage keyed by `buildId`).
 
 ### 2. kn-next Package
 
@@ -165,22 +167,24 @@ The BUILD_ID ensures server and client assets are always in sync:
 
 ```text
 ┌─────────────────────────────────────────────────────┐
-│                     GCS (Data Cache)                │
-│  - ISR page cache                                   │
+│              Redis (ISR / Data Cache)               │
+│  - ISR page cache (cache-handler.js)                │
 │  - Fetch cache                                      │
-│  - Image optimization cache                         │
-│  Keyed by: {prefix}/{BUILD_ID}/{key}.{type}        │
+│  - Tag → Keys mapping for invalidation              │
+│  Keyed by: {prefix}/{key}                           │
 └─────────────────────────────────────────────────────┘
-                          ▲
-                          │ Keys lookup for invalidation
-                          ▼
+
 ┌─────────────────────────────────────────────────────┐
-│                  Redis (Tag Cache)                  │
-│  - Tag → Keys mapping                              │
-│  - Fast O(1) invalidation                          │
-│  Keyed by: {prefix}:tag:{tagName}                  │
+│              GCS (Static Assets only)               │
+│  - _next/static/ (JS, CSS, fonts)                  │
+│  - Uploaded at build time keyed by buildId          │
+│  NOT used for ISR/data cache (that is Redis)        │
 └─────────────────────────────────────────────────────┘
 ```
+
+> **Correction from earlier docs:** GCS holds **static assets only**. The ISR/data cache
+> (`cache-handler.js`) is backed by **Redis**. S3/Azure/MinIO are thin shell-outs;
+> DynamoDB/Kafka are config/manifest-only and not yet implemented end-to-end.
 
 ### Cache Events (Observability)
 
@@ -207,7 +211,7 @@ The environment variables depend on your chosen storage and cache providers.
 | Variable | Description | Default |
 | ---------- | ------------- | --------- |
 | `NODE_ENV` | Runtime environment | `production` |
-| `NEXT_BUILD_ID` | From Vinext build | Auto |
+| `NEXT_BUILD_ID` | From `next build` | Auto |
 | `DATABASE_URL` | PostgreSQL connection | Required |
 | `NODE_COMPILE_CACHE` | V8 bytecode cache path | Optional |
 
@@ -300,7 +304,7 @@ Knative scale-to-zero services incur a cold start cost each time a pod is create
 ```mermaid
 flowchart LR
     subgraph Stage1["Stage 1: Build"]
-        A["node:22-alpine + pnpm"] --> B["Vinext/Nitro<br/>Application Bundle"]
+        A["node:22-alpine + pnpm"] --> B["next build<br/>output:standalone"]
     end
 
     subgraph Stage2["Stage 2: Compile"]
@@ -409,7 +413,7 @@ npx kn-next deploy [options]
 | `--bucket <name>` | `-b` | Override storage bucket |
 | `--tag <tag>` | `-t` | Image tag (default: timestamp) |
 | `--namespace <ns>` | `-n` | Kubernetes namespace (default: default) |
-| `--skip-build` | | Skip Vinext build step |
+| `--skip-build` | | Skip Next.js build step |
 | `--skip-upload` | | Skip asset upload to storage |
 | `--skip-infra` | | Skip infrastructure deployment |
 | `--dry-run` | | Generate manifests without deploying |
@@ -541,10 +545,10 @@ npx kn-next build
 
 Runs the following steps:
 
-1. Generates `open-next.config.ts` from `kn-next.config.ts`
-2. Runs `npm run build` (Next.js build)
-3. Runs Vinext compilation
-4. Copies adapter files to `.open-next/`
+1. Loads `kn-next.config.ts`
+2. Runs `npm run build` (`next build` with `output:'standalone'`)
+3. Uploads static assets to GCS/S3/MinIO
+4. Generates `knative-service.yaml` in `.output/`
 
 ### Cleanup Command
 
@@ -583,26 +587,25 @@ Removes deployed resources from the cluster:
 
    ```bash
    npx kn-next deploy --dry-run
-   cat .open-next/knative-service.yaml
+   cat .output/knative-service.yaml
    ```
 
 5. **Manual Steps (if needed):**
 
    ```bash
-   # Build Next.js + Vinext
+   # Build Next.js with standalone output
    cd apps/file-manager
-   pnpm build
-   npx open-next build
-   
-   # Sync assets
-   gsutil -m rsync -r .open-next/assets gs://bucket
-   
+   pnpm build   # runs next build → .next/standalone/
+
+   # Upload static assets to GCS
+   gsutil -m rsync -r .next/static gs://bucket/_next/static
+
    # Build & push image
    docker buildx build --platform linux/amd64 \
      -t registry/file-manager:tag -f Dockerfile . --push
-   
+
    # Deploy
-   kubectl apply -f .open-next/knative-service.yaml
+   kubectl apply -f .output/knative-service.yaml
    ```
 
 ## Future Roadmap

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,8 +58,8 @@ The `@kn-next/config` package provides pluggable adapters:
 
 | Adapter | Purpose | Implementation |
 | --------- | --------- | ---------------- |
-| **GCS Cache** | ISR data cache | `gcs-cache.ts` |
-| **Redis Tag Cache** | Cache invalidation tags | `redis-tag-cache.ts` |
+| **GCS Storage** | Static assets only (NOT ISR) | — |
+| **Redis Cache** | ISR/data cache + tag invalidation | `cache-handler.js` |
 | **Kafka Queue** | Revalidation queue | `kafka-queue.ts` |
 | **Node Server** | HTTP server wrapper | `node-server.ts` |
 
@@ -99,21 +99,21 @@ const config: KnativeNextConfig = {
 sequenceDiagram
     participant Browser
     participant Knative as Knative Service
-    participant GCS as GCS Cache
-    participant Redis as Redis Tags
+    participant Redis as Redis (ISR/Data Cache)
+    participant GCS as GCS (Static Assets)
     participant Next as Next.js Runtime
-    
+
     Browser->>Knative: GET /page
-    Knative->>GCS: Check ISR cache
-    
+    Knative->>Redis: Check ISR cache (cache-handler.js)
+
     alt Cache HIT
-        GCS-->>Knative: Cached HTML + stale-while-revalidate
+        Redis-->>Knative: Cached HTML + stale-while-revalidate
         Knative-->>Browser: 200 OK (cached)
         Note over Knative: Background revalidation if stale
     else Cache MISS
         Knative->>Next: Render page
-        Next->>GCS: Store in cache
-        Next->>Redis: Store tags
+        Next->>Redis: Store rendered page in ISR cache
+        Next->>Redis: Store cache tags
         Knative-->>Browser: 200 OK (fresh)
     end
 ```
@@ -124,14 +124,14 @@ sequenceDiagram
 sequenceDiagram
     participant Admin
     participant API as /api/cache/invalidate
-    participant Redis as Redis Tags
-    participant GCS as GCS Cache
+    participant Redis as Redis (ISR/Data Cache)
+    participant GCS as GCS (Static Assets Only)
     
     Admin->>API: POST /api/cache/invalidate {tag: "products"}
     API->>Redis: Get keys for tag "products"
     Redis-->>API: ["key1", "key2", "key3"]
     loop For each key
-        API->>GCS: Delete cached entry
+        API->>Redis: Delete ISR cache entry (cache-handler.js)
     end
     API->>Redis: Clear tag mapping
     API-->>Admin: 200 OK {invalidated: 3}

--- a/docs/VINEXT_MIGRATION_PLAN.md
+++ b/docs/VINEXT_MIGRATION_PLAN.md
@@ -1,6 +1,21 @@
-# Migration Plan: OpenNext & Turbopack ➡️ Vinext
+# HISTORICAL / SUPERSEDED — Migration Plan: OpenNext & Turbopack ➡️ Vinext
 
-This document outlines the strategy for migrating the `Knative-open-nextjs` architecture from its current build system (Turbopack + OpenNext) to [Vinext](https://github.com/cloudflare/vinext) (Vite-based Next.js reimplementation).
+> **This document is SUPERSEDED.** The Vinext migration was an intermediate step that
+> has been retired. knext now runs on the **official Next.js Deployment Adapter API**
+> (`experimental.adapterPath`, `NextAdapter`) with `output:'standalone'`. See:
+> - `docs/ARCHITECTURE.md` — current architecture
+> - `docs/adr/` — ADR-0001 (operator), ADR-0002/0003/0004 (gRPC layer)
+> - `apps/file-manager/next-adapter.ts` — reference NextAdapter implementation
+>
+> Retained for historical context only.
+
+---
+
+# Migration Plan: OpenNext & Turbopack ➡️ Vinext (HISTORICAL)
+
+This document outlines the original strategy for migrating the `Knative-open-nextjs`
+architecture from Turbopack + OpenNext to Vinext (Vite-based Next.js reimplementation).
+That path was superseded by the official adapter approach described above.
 
 ## 1. Dependency Updates
 *   **Remove OpenNext:** Uninstall `@opennextjs/aws` from `apps/file-manager` and `packages/kn-next`.

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -1,6 +1,6 @@
 # Knative Next.js Operator (`kn-next-operator`)
 
-The `kn-next-operator` is a Kubernetes Operator built with Kubebuilder that serves as the control plane for the `kn-next` ecosystem. It transforms standard Kubernetes clusters into a seamless, "Vercel-equivalent" Platform-as-a-Service (PaaS) for Next.js applications deployed on Vinext and Knative.
+The `kn-next-operator` is a Kubernetes Operator built with Kubebuilder that serves as the control plane for the `kn-next` ecosystem. It transforms standard Kubernetes clusters into a seamless, "Vercel-equivalent" Platform-as-a-Service (PaaS) for Next.js applications deployed with the official Next.js Adapter (`output:'standalone'`) on Knative.
 
 ## Architecture & Responsibilities
 

--- a/docs/operator/crd-nextapp.md
+++ b/docs/operator/crd-nextapp.md
@@ -1,6 +1,6 @@
 # The `NextApp` Custom Resource Definition (CRD)
 
-The `NextApp` CRD is the unified interface for deploying Vinext applications onto Knative. It abstracts the underlying Knative Services, PVCs, ServiceAccounts, and Eventing bindings into a single declarative API.
+The `NextApp` CRD is the unified interface for deploying Next.js applications (built with `output:'standalone'` via the official adapter) onto Knative. It abstracts the underlying Knative Services, PVCs, ServiceAccounts, and Eventing bindings into a single declarative API.
 
 ## API Version & Kind
 ```yaml
@@ -13,7 +13,7 @@ kind: NextApp
 The `spec` defines the desired state of the Next.js application.
 
 ### `image` (Required)
-The absolute OCI registry path to the Next.js container image built by Vinext.
+The absolute OCI registry path to the Next.js container image (built from `output:'standalone'`).
 ```yaml
 spec:
   image: ghcr.io/org/repo/app:latest

--- a/docs/spikes/0001-bun-bytecode-pipeline.md
+++ b/docs/spikes/0001-bun-bytecode-pipeline.md
@@ -1,5 +1,10 @@
 # Spike Report: Bun Bytecode Pipeline for Native Next.js Standalone
 
+> **HISTORICAL NOTE:** This spike was conducted during the Vinext/Nitro era as a
+> comparison path. The official Next.js Adapter + `output:'standalone'` is now the
+> knext runtime path. The Bun `--compile --bytecode` approach described here remains
+> a valid cold-start optimization technique but is not the primary deployment path.
+
 ## Status: GO ✅
 
 ## Executive Summary
@@ -31,4 +36,6 @@ The recommended production pipeline is:
 - **Static Assets**: Per the architecture, `.next/static` and `public` folders should NOT be embedded; they should be offloaded to object storage.
 
 ## Conclusion
-The Bun-bytecode pipeline is a viable and superior replacement for the Vinext/Nitro pipeline. It satisfies all security requirements for regulated buyers by providing an audit-clean dependency tree and a single-binary distribution.
+The Bun-bytecode pipeline is a viable cold-start optimization on top of the official
+`output:'standalone'` runtime. It satisfies all security requirements for regulated buyers
+by providing an audit-clean dependency tree and a single-binary distribution.

--- a/packages/kn-next/package.json
+++ b/packages/kn-next/package.json
@@ -19,7 +19,7 @@
     "./cli/shared": "./src/cli/shared.ts"
   },
   "scripts": {
-    "build": "bun run ./src/cli/build.ts",
+    "build": "tsc --noEmit",
     "deploy": "bun run ./src/cli/deploy.ts",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",

--- a/packages/kn-next/src/__tests__/adapter-migration.test.ts
+++ b/packages/kn-next/src/__tests__/adapter-migration.test.ts
@@ -13,114 +13,116 @@
  *  - config.ts runtime field comment does not mention "Nitro preset"
  */
 
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 
 // Locate the kn-next src directory relative to this __tests__ file.
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
-const SRC = resolve(TESTS_DIR, '..');
+const SRC = resolve(TESTS_DIR, "..");
 
 function readSrc(relPath: string): string {
-  return readFileSync(resolve(SRC, relPath), 'utf-8');
+    return readFileSync(resolve(SRC, relPath), "utf-8");
 }
 
 // ─── shared.ts: Nitro exports removed ────────────────────────────────────────
 
-describe('shared.ts: Nitro APIs removed', () => {
-  it('does NOT export getNitroPreset', async () => {
-    const mod = await import('../cli/shared');
-    expect('getNitroPreset' in mod).toBe(false);
-  });
+describe("shared.ts: Nitro APIs removed", () => {
+    it("does NOT export getNitroPreset", async () => {
+        const mod = await import("../cli/shared");
+        expect("getNitroPreset" in mod).toBe(false);
+    });
 
-  it('does NOT export copyAdapters (Nitro .output copy removed)', async () => {
-    const mod = await import('../cli/shared');
-    expect('copyAdapters' in mod).toBe(false);
-  });
+    it("does NOT export copyAdapters (Nitro .output copy removed)", async () => {
+        const mod = await import("../cli/shared");
+        expect("copyAdapters" in mod).toBe(false);
+    });
 
-  it('still exports loadConfig', async () => {
-    const mod = await import('../cli/shared');
-    expect(typeof (mod as Record<string, unknown>).loadConfig).toBe('function');
-  });
+    it("still exports loadConfig", async () => {
+        const mod = await import("../cli/shared");
+        expect(typeof (mod as Record<string, unknown>).loadConfig).toBe(
+            "function",
+        );
+    });
 });
 
 // ─── build.ts: no Nitro build orchestration ───────────────────────────────────
 
-describe('build.ts: no Nitro build orchestration', () => {
-  it('does NOT contain NITRO_PRESET env var', () => {
-    expect(readSrc('cli/build.ts')).not.toMatch(/NITRO_PRESET/);
-  });
+describe("build.ts: no Nitro build orchestration", () => {
+    it("does NOT contain NITRO_PRESET env var", () => {
+        expect(readSrc("cli/build.ts")).not.toMatch(/NITRO_PRESET/);
+    });
 
-  it('does NOT call getNitroPreset', () => {
-    expect(readSrc('cli/build.ts')).not.toContain('getNitroPreset');
-  });
+    it("does NOT call getNitroPreset", () => {
+        expect(readSrc("cli/build.ts")).not.toContain("getNitroPreset");
+    });
 
-  it('does NOT call copyAdapters', () => {
-    expect(readSrc('cli/build.ts')).not.toContain('copyAdapters');
-  });
+    it("does NOT call copyAdapters", () => {
+        expect(readSrc("cli/build.ts")).not.toContain("copyAdapters");
+    });
 });
 
 // ─── deploy.ts: no Nitro build orchestration ──────────────────────────────────
 
-describe('deploy.ts: no Nitro build orchestration', () => {
-  it('does NOT contain NITRO_PRESET env var', () => {
-    expect(readSrc('cli/deploy.ts')).not.toMatch(/NITRO_PRESET/);
-  });
+describe("deploy.ts: no Nitro build orchestration", () => {
+    it("does NOT contain NITRO_PRESET env var", () => {
+        expect(readSrc("cli/deploy.ts")).not.toMatch(/NITRO_PRESET/);
+    });
 
-  it('does NOT call getNitroPreset', () => {
-    expect(readSrc('cli/deploy.ts')).not.toContain('getNitroPreset');
-  });
+    it("does NOT call getNitroPreset", () => {
+        expect(readSrc("cli/deploy.ts")).not.toContain("getNitroPreset");
+    });
 
-  it('does NOT call copyAdapters', () => {
-    expect(readSrc('cli/deploy.ts')).not.toContain('copyAdapters');
-  });
+    it("does NOT call copyAdapters", () => {
+        expect(readSrc("cli/deploy.ts")).not.toContain("copyAdapters");
+    });
 });
 
 // ─── node-server.ts: standalone runtime, not Nitro ───────────────────────────
 
-describe('node-server.ts: starts Next.js standalone server, not Nitro', () => {
-  it('does NOT import Nitro server (index.mjs / .output/server)', () => {
-    const src = readSrc('adapters/node-server.ts');
-    expect(src).not.toContain('index.mjs');
-    expect(src).not.toContain('.output/server');
-  });
+describe("node-server.ts: starts Next.js standalone server, not Nitro", () => {
+    it("does NOT import Nitro server (index.mjs / .output/server)", () => {
+        const src = readSrc("adapters/node-server.ts");
+        expect(src).not.toContain("index.mjs");
+        expect(src).not.toContain(".output/server");
+    });
 
-  it('references the Next.js standalone server.js entry point', () => {
-    expect(readSrc('adapters/node-server.ts')).toMatch(/server\.js/);
-  });
+    it("references the Next.js standalone server.js entry point", () => {
+        expect(readSrc("adapters/node-server.ts")).toMatch(/server\.js/);
+    });
 });
 
 // ─── config.ts: runtime field is standalone-oriented, not Nitro ──────────────
 
-describe('config.ts: runtime field describes standalone, not Nitro preset', () => {
-  it('does NOT describe runtime as a "Nitro preset"', () => {
-    expect(readSrc('config.ts')).not.toMatch(/Nitro preset/i);
-  });
+describe("config.ts: runtime field describes standalone, not Nitro preset", () => {
+    it('does NOT describe runtime as a "Nitro preset"', () => {
+        expect(readSrc("config.ts")).not.toMatch(/Nitro preset/i);
+    });
 });
 
 // ─── apps/file-manager: no regression on the official adapter ─────────────────
 // The app already uses the official NextAdapter via experimental.adapterPath.
 // Verify the next-adapter.ts and next.config.ts remain on that path.
 
-describe('apps/file-manager: official adapter, not Nitro', () => {
-  const APP_SRC = resolve(TESTS_DIR, '../../../../apps/file-manager');
+describe("apps/file-manager: official adapter, not Nitro", () => {
+    const APP_SRC = resolve(TESTS_DIR, "../../../../apps/file-manager");
 
-  function readApp(relPath: string): string {
-    return readFileSync(resolve(APP_SRC, relPath), 'utf-8');
-  }
+    function readApp(relPath: string): string {
+        return readFileSync(resolve(APP_SRC, relPath), "utf-8");
+    }
 
-  it('next-adapter.ts uses official NextAdapter interface (not Nitro)', () => {
-    const src = readApp('next-adapter.ts');
-    // Must import NextAdapter from 'next'
-    expect(src).toMatch(/from\s+['"]next['"]/);
-    // Must not use Nitro-style imports
-    expect(src).not.toContain('index.mjs');
-  });
+    it("next-adapter.ts uses official NextAdapter interface (not Nitro)", () => {
+        const src = readApp("next-adapter.ts");
+        // Must import NextAdapter from 'next'
+        expect(src).toMatch(/from\s+['"]next['"]/);
+        // Must not use Nitro-style imports
+        expect(src).not.toContain("index.mjs");
+    });
 
-  it('next.config.ts sets output:standalone and adapterPath (official adapter)', () => {
-    const src = readApp('next.config.ts');
-    expect(src).toContain("output: 'standalone'");
-    expect(src).toContain('adapterPath');
-  });
+    it("next.config.ts sets output:standalone and adapterPath (official adapter)", () => {
+        const src = readApp("next.config.ts");
+        expect(src).toContain("output: 'standalone'");
+        expect(src).toContain("adapterPath");
+    });
 });

--- a/packages/kn-next/src/__tests__/adapter-migration.test.ts
+++ b/packages/kn-next/src/__tests__/adapter-migration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for the vinext → official Next.js Adapter migration.
+ *
+ * These tests assert that Nitro/Vinext build APIs are fully removed from the
+ * kn-next framework packages, and that the official `output:'standalone'` path
+ * is wired instead. Written RED-first per superteam TDD discipline.
+ *
+ * Tested invariants:
+ *  - shared.ts no longer exports getNitroPreset or copyAdapters (Nitro-specific)
+ *  - build.ts source does not reference NITRO_PRESET or getNitroPreset
+ *  - deploy.ts source does not reference NITRO_PRESET or getNitroPreset
+ *  - node-server.ts does not import Nitro's index.mjs; starts standalone server.js
+ *  - config.ts runtime field comment does not mention "Nitro preset"
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Locate the kn-next src directory relative to this __tests__ file.
+const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(TESTS_DIR, '..');
+
+function readSrc(relPath: string): string {
+  return readFileSync(resolve(SRC, relPath), 'utf-8');
+}
+
+// ─── shared.ts: Nitro exports removed ────────────────────────────────────────
+
+describe('shared.ts: Nitro APIs removed', () => {
+  it('does NOT export getNitroPreset', async () => {
+    const mod = await import('../cli/shared');
+    expect('getNitroPreset' in mod).toBe(false);
+  });
+
+  it('does NOT export copyAdapters (Nitro .output copy removed)', async () => {
+    const mod = await import('../cli/shared');
+    expect('copyAdapters' in mod).toBe(false);
+  });
+
+  it('still exports loadConfig', async () => {
+    const mod = await import('../cli/shared');
+    expect(typeof (mod as Record<string, unknown>).loadConfig).toBe('function');
+  });
+});
+
+// ─── build.ts: no Nitro build orchestration ───────────────────────────────────
+
+describe('build.ts: no Nitro build orchestration', () => {
+  it('does NOT contain NITRO_PRESET env var', () => {
+    expect(readSrc('cli/build.ts')).not.toMatch(/NITRO_PRESET/);
+  });
+
+  it('does NOT call getNitroPreset', () => {
+    expect(readSrc('cli/build.ts')).not.toContain('getNitroPreset');
+  });
+
+  it('does NOT call copyAdapters', () => {
+    expect(readSrc('cli/build.ts')).not.toContain('copyAdapters');
+  });
+});
+
+// ─── deploy.ts: no Nitro build orchestration ──────────────────────────────────
+
+describe('deploy.ts: no Nitro build orchestration', () => {
+  it('does NOT contain NITRO_PRESET env var', () => {
+    expect(readSrc('cli/deploy.ts')).not.toMatch(/NITRO_PRESET/);
+  });
+
+  it('does NOT call getNitroPreset', () => {
+    expect(readSrc('cli/deploy.ts')).not.toContain('getNitroPreset');
+  });
+
+  it('does NOT call copyAdapters', () => {
+    expect(readSrc('cli/deploy.ts')).not.toContain('copyAdapters');
+  });
+});
+
+// ─── node-server.ts: standalone runtime, not Nitro ───────────────────────────
+
+describe('node-server.ts: starts Next.js standalone server, not Nitro', () => {
+  it('does NOT import Nitro server (index.mjs / .output/server)', () => {
+    const src = readSrc('adapters/node-server.ts');
+    expect(src).not.toContain('index.mjs');
+    expect(src).not.toContain('.output/server');
+  });
+
+  it('references the Next.js standalone server.js entry point', () => {
+    expect(readSrc('adapters/node-server.ts')).toMatch(/server\.js/);
+  });
+});
+
+// ─── config.ts: runtime field is standalone-oriented, not Nitro ──────────────
+
+describe('config.ts: runtime field describes standalone, not Nitro preset', () => {
+  it('does NOT describe runtime as a "Nitro preset"', () => {
+    expect(readSrc('config.ts')).not.toMatch(/Nitro preset/i);
+  });
+});

--- a/packages/kn-next/src/__tests__/adapter-migration.test.ts
+++ b/packages/kn-next/src/__tests__/adapter-migration.test.ts
@@ -98,3 +98,29 @@ describe('config.ts: runtime field describes standalone, not Nitro preset', () =
     expect(readSrc('config.ts')).not.toMatch(/Nitro preset/i);
   });
 });
+
+// ─── apps/file-manager: no regression on the official adapter ─────────────────
+// The app already uses the official NextAdapter via experimental.adapterPath.
+// Verify the next-adapter.ts and next.config.ts remain on that path.
+
+describe('apps/file-manager: official adapter, not Nitro', () => {
+  const APP_SRC = resolve(TESTS_DIR, '../../../../apps/file-manager');
+
+  function readApp(relPath: string): string {
+    return readFileSync(resolve(APP_SRC, relPath), 'utf-8');
+  }
+
+  it('next-adapter.ts uses official NextAdapter interface (not Nitro)', () => {
+    const src = readApp('next-adapter.ts');
+    // Must import NextAdapter from 'next'
+    expect(src).toMatch(/from\s+['"]next['"]/);
+    // Must not use Nitro-style imports
+    expect(src).not.toContain('index.mjs');
+  });
+
+  it('next.config.ts sets output:standalone and adapterPath (official adapter)', () => {
+    const src = readApp('next.config.ts');
+    expect(src).toContain("output: 'standalone'");
+    expect(src).toContain('adapterPath');
+  });
+});

--- a/packages/kn-next/src/__tests__/adapter-migration.test.ts
+++ b/packages/kn-next/src/__tests__/adapter-migration.test.ts
@@ -13,90 +13,92 @@
  *  - config.ts runtime field comment does not mention "Nitro preset"
  */
 
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 
 // Locate the kn-next src directory relative to this __tests__ file.
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
-const SRC = resolve(TESTS_DIR, '..');
+const SRC = resolve(TESTS_DIR, "..");
 
 function readSrc(relPath: string): string {
-  return readFileSync(resolve(SRC, relPath), 'utf-8');
+    return readFileSync(resolve(SRC, relPath), "utf-8");
 }
 
 // ─── shared.ts: Nitro exports removed ────────────────────────────────────────
 
-describe('shared.ts: Nitro APIs removed', () => {
-  it('does NOT export getNitroPreset', async () => {
-    const mod = await import('../cli/shared');
-    expect('getNitroPreset' in mod).toBe(false);
-  });
+describe("shared.ts: Nitro APIs removed", () => {
+    it("does NOT export getNitroPreset", async () => {
+        const mod = await import("../cli/shared");
+        expect("getNitroPreset" in mod).toBe(false);
+    });
 
-  it('does NOT export copyAdapters (Nitro .output copy removed)', async () => {
-    const mod = await import('../cli/shared');
-    expect('copyAdapters' in mod).toBe(false);
-  });
+    it("does NOT export copyAdapters (Nitro .output copy removed)", async () => {
+        const mod = await import("../cli/shared");
+        expect("copyAdapters" in mod).toBe(false);
+    });
 
-  it('still exports loadConfig', async () => {
-    const mod = await import('../cli/shared');
-    expect(typeof (mod as Record<string, unknown>).loadConfig).toBe('function');
-  });
+    it("still exports loadConfig", async () => {
+        const mod = await import("../cli/shared");
+        expect(typeof (mod as Record<string, unknown>).loadConfig).toBe(
+            "function",
+        );
+    });
 });
 
 // ─── build.ts: no Nitro build orchestration ───────────────────────────────────
 
-describe('build.ts: no Nitro build orchestration', () => {
-  it('does NOT contain NITRO_PRESET env var', () => {
-    expect(readSrc('cli/build.ts')).not.toMatch(/NITRO_PRESET/);
-  });
+describe("build.ts: no Nitro build orchestration", () => {
+    it("does NOT contain NITRO_PRESET env var", () => {
+        expect(readSrc("cli/build.ts")).not.toMatch(/NITRO_PRESET/);
+    });
 
-  it('does NOT call getNitroPreset', () => {
-    expect(readSrc('cli/build.ts')).not.toContain('getNitroPreset');
-  });
+    it("does NOT call getNitroPreset", () => {
+        expect(readSrc("cli/build.ts")).not.toContain("getNitroPreset");
+    });
 
-  it('does NOT call copyAdapters', () => {
-    expect(readSrc('cli/build.ts')).not.toContain('copyAdapters');
-  });
+    it("does NOT call copyAdapters", () => {
+        expect(readSrc("cli/build.ts")).not.toContain("copyAdapters");
+    });
 });
 
 // ─── deploy.ts: no Nitro build orchestration ──────────────────────────────────
 
-describe('deploy.ts: no Nitro build orchestration', () => {
-  it('does NOT contain NITRO_PRESET env var', () => {
-    expect(readSrc('cli/deploy.ts')).not.toMatch(/NITRO_PRESET/);
-  });
+describe("deploy.ts: no Nitro build orchestration", () => {
+    it("does NOT contain NITRO_PRESET env var", () => {
+        expect(readSrc("cli/deploy.ts")).not.toMatch(/NITRO_PRESET/);
+    });
 
-  it('does NOT call getNitroPreset', () => {
-    expect(readSrc('cli/deploy.ts')).not.toContain('getNitroPreset');
-  });
+    it("does NOT call getNitroPreset", () => {
+        expect(readSrc("cli/deploy.ts")).not.toContain("getNitroPreset");
+    });
 
-  it('does NOT call copyAdapters', () => {
-    expect(readSrc('cli/deploy.ts')).not.toContain('copyAdapters');
-  });
+    it("does NOT call copyAdapters", () => {
+        expect(readSrc("cli/deploy.ts")).not.toContain("copyAdapters");
+    });
 });
 
 // ─── node-server.ts: standalone runtime, not Nitro ───────────────────────────
 
-describe('node-server.ts: starts Next.js standalone server, not Nitro', () => {
-  it('does NOT import Nitro server (index.mjs / .output/server)', () => {
-    const src = readSrc('adapters/node-server.ts');
-    expect(src).not.toContain('index.mjs');
-    expect(src).not.toContain('.output/server');
-  });
+describe("node-server.ts: starts Next.js standalone server, not Nitro", () => {
+    it("does NOT import Nitro server (index.mjs / .output/server)", () => {
+        const src = readSrc("adapters/node-server.ts");
+        expect(src).not.toContain("index.mjs");
+        expect(src).not.toContain(".output/server");
+    });
 
-  it('references the Next.js standalone server.js entry point', () => {
-    expect(readSrc('adapters/node-server.ts')).toMatch(/server\.js/);
-  });
+    it("references the Next.js standalone server.js entry point", () => {
+        expect(readSrc("adapters/node-server.ts")).toMatch(/server\.js/);
+    });
 });
 
 // ─── config.ts: runtime field is standalone-oriented, not Nitro ──────────────
 
-describe('config.ts: runtime field describes standalone, not Nitro preset', () => {
-  it('does NOT describe runtime as a "Nitro preset"', () => {
-    expect(readSrc('config.ts')).not.toMatch(/Nitro preset/i);
-  });
+describe("config.ts: runtime field describes standalone, not Nitro preset", () => {
+    it('does NOT describe runtime as a "Nitro preset"', () => {
+        expect(readSrc("config.ts")).not.toMatch(/Nitro preset/i);
+    });
 });
 
 // ─── apps/file-manager: no regression on the official adapter ─────────────────
@@ -109,67 +111,69 @@ describe('config.ts: runtime field describes standalone, not Nitro preset', () =
 // The operator injects NODE_COMPILE_CACHE pointing at a PVC for cross-pod caching;
 // the standalone server MUST inherit it — never hardcode or override it.
 
-describe('node-server: NODE_COMPILE_CACHE forwarded to spawned server', () => {
-  it('buildChildEnv inherits NODE_COMPILE_CACHE from process.env when set', async () => {
-    const { buildChildEnv } = await import('../adapters/env');
-    const saved = process.env.NODE_COMPILE_CACHE;
-    try {
-      process.env.NODE_COMPILE_CACHE = '/test/compile-cache';
-      expect(buildChildEnv().NODE_COMPILE_CACHE).toBe('/test/compile-cache');
-    } finally {
-      if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
-      else process.env.NODE_COMPILE_CACHE = saved;
-    }
-  });
+describe("node-server: NODE_COMPILE_CACHE forwarded to spawned server", () => {
+    it("buildChildEnv inherits NODE_COMPILE_CACHE from process.env when set", async () => {
+        const { buildChildEnv } = await import("../adapters/env");
+        const saved = process.env.NODE_COMPILE_CACHE;
+        try {
+            process.env.NODE_COMPILE_CACHE = "/test/compile-cache";
+            expect(buildChildEnv().NODE_COMPILE_CACHE).toBe(
+                "/test/compile-cache",
+            );
+        } finally {
+            if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
+            else process.env.NODE_COMPILE_CACHE = saved;
+        }
+    });
 
-  it('externally-set NODE_COMPILE_CACHE is not clobbered (operator PVC path wins)', async () => {
-    const { buildChildEnv } = await import('../adapters/env');
-    const saved = process.env.NODE_COMPILE_CACHE;
-    try {
-      process.env.NODE_COMPILE_CACHE = '/operator-pvc/bytecode-cache';
-      const env = buildChildEnv();
-      expect(env.NODE_COMPILE_CACHE).toBe('/operator-pvc/bytecode-cache');
-    } finally {
-      if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
-      else process.env.NODE_COMPILE_CACHE = saved;
-    }
-  });
+    it("externally-set NODE_COMPILE_CACHE is not clobbered (operator PVC path wins)", async () => {
+        const { buildChildEnv } = await import("../adapters/env");
+        const saved = process.env.NODE_COMPILE_CACHE;
+        try {
+            process.env.NODE_COMPILE_CACHE = "/operator-pvc/bytecode-cache";
+            const env = buildChildEnv();
+            expect(env.NODE_COMPILE_CACHE).toBe("/operator-pvc/bytecode-cache");
+        } finally {
+            if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
+            else process.env.NODE_COMPILE_CACHE = saved;
+        }
+    });
 
-  it('NODE_COMPILE_CACHE absent from env when not set (no hardcoded fallback in buildChildEnv)', async () => {
-    const { buildChildEnv } = await import('../adapters/env');
-    const saved = process.env.NODE_COMPILE_CACHE;
-    try {
-      delete process.env.NODE_COMPILE_CACHE;
-      // Must be undefined — the Dockerfile CMD supplies the fallback, not the code
-      expect(buildChildEnv().NODE_COMPILE_CACHE).toBeUndefined();
-    } finally {
-      if (saved !== undefined) process.env.NODE_COMPILE_CACHE = saved;
-    }
-  });
+    it("NODE_COMPILE_CACHE absent from env when not set (no hardcoded fallback in buildChildEnv)", async () => {
+        const { buildChildEnv } = await import("../adapters/env");
+        const saved = process.env.NODE_COMPILE_CACHE;
+        try {
+            delete process.env.NODE_COMPILE_CACHE;
+            // Must be undefined — the Dockerfile CMD supplies the fallback, not the code
+            expect(buildChildEnv().NODE_COMPILE_CACHE).toBeUndefined();
+        } finally {
+            if (saved !== undefined) process.env.NODE_COMPILE_CACHE = saved;
+        }
+    });
 });
 
 // ─── apps/file-manager: no regression on the official adapter ─────────────────
 // The app already uses the official NextAdapter via experimental.adapterPath.
 // Verify the next-adapter.ts and next.config.ts remain on that path.
 
-describe('apps/file-manager: official adapter, not Nitro', () => {
-  const APP_SRC = resolve(TESTS_DIR, '../../../../apps/file-manager');
+describe("apps/file-manager: official adapter, not Nitro", () => {
+    const APP_SRC = resolve(TESTS_DIR, "../../../../apps/file-manager");
 
-  function readApp(relPath: string): string {
-    return readFileSync(resolve(APP_SRC, relPath), 'utf-8');
-  }
+    function readApp(relPath: string): string {
+        return readFileSync(resolve(APP_SRC, relPath), "utf-8");
+    }
 
-  it('next-adapter.ts uses official NextAdapter interface (not Nitro)', () => {
-    const src = readApp('next-adapter.ts');
-    // Must import NextAdapter from 'next'
-    expect(src).toMatch(/from\s+['"]next['"]/);
-    // Must not use Nitro-style imports
-    expect(src).not.toContain('index.mjs');
-  });
+    it("next-adapter.ts uses official NextAdapter interface (not Nitro)", () => {
+        const src = readApp("next-adapter.ts");
+        // Must import NextAdapter from 'next'
+        expect(src).toMatch(/from\s+['"]next['"]/);
+        // Must not use Nitro-style imports
+        expect(src).not.toContain("index.mjs");
+    });
 
-  it('next.config.ts sets output:standalone and adapterPath (official adapter)', () => {
-    const src = readApp('next.config.ts');
-    expect(src).toContain("output: 'standalone'");
-    expect(src).toContain('adapterPath');
-  });
+    it("next.config.ts sets output:standalone and adapterPath (official adapter)", () => {
+        const src = readApp("next.config.ts");
+        expect(src).toContain("output: 'standalone'");
+        expect(src).toContain("adapterPath");
+    });
 });

--- a/packages/kn-next/src/__tests__/adapter-migration.test.ts
+++ b/packages/kn-next/src/__tests__/adapter-migration.test.ts
@@ -13,116 +13,163 @@
  *  - config.ts runtime field comment does not mention "Nitro preset"
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 
 // Locate the kn-next src directory relative to this __tests__ file.
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
-const SRC = resolve(TESTS_DIR, "..");
+const SRC = resolve(TESTS_DIR, '..');
 
 function readSrc(relPath: string): string {
-    return readFileSync(resolve(SRC, relPath), "utf-8");
+  return readFileSync(resolve(SRC, relPath), 'utf-8');
 }
 
 // ─── shared.ts: Nitro exports removed ────────────────────────────────────────
 
-describe("shared.ts: Nitro APIs removed", () => {
-    it("does NOT export getNitroPreset", async () => {
-        const mod = await import("../cli/shared");
-        expect("getNitroPreset" in mod).toBe(false);
-    });
+describe('shared.ts: Nitro APIs removed', () => {
+  it('does NOT export getNitroPreset', async () => {
+    const mod = await import('../cli/shared');
+    expect('getNitroPreset' in mod).toBe(false);
+  });
 
-    it("does NOT export copyAdapters (Nitro .output copy removed)", async () => {
-        const mod = await import("../cli/shared");
-        expect("copyAdapters" in mod).toBe(false);
-    });
+  it('does NOT export copyAdapters (Nitro .output copy removed)', async () => {
+    const mod = await import('../cli/shared');
+    expect('copyAdapters' in mod).toBe(false);
+  });
 
-    it("still exports loadConfig", async () => {
-        const mod = await import("../cli/shared");
-        expect(typeof (mod as Record<string, unknown>).loadConfig).toBe(
-            "function",
-        );
-    });
+  it('still exports loadConfig', async () => {
+    const mod = await import('../cli/shared');
+    expect(typeof (mod as Record<string, unknown>).loadConfig).toBe('function');
+  });
 });
 
 // ─── build.ts: no Nitro build orchestration ───────────────────────────────────
 
-describe("build.ts: no Nitro build orchestration", () => {
-    it("does NOT contain NITRO_PRESET env var", () => {
-        expect(readSrc("cli/build.ts")).not.toMatch(/NITRO_PRESET/);
-    });
+describe('build.ts: no Nitro build orchestration', () => {
+  it('does NOT contain NITRO_PRESET env var', () => {
+    expect(readSrc('cli/build.ts')).not.toMatch(/NITRO_PRESET/);
+  });
 
-    it("does NOT call getNitroPreset", () => {
-        expect(readSrc("cli/build.ts")).not.toContain("getNitroPreset");
-    });
+  it('does NOT call getNitroPreset', () => {
+    expect(readSrc('cli/build.ts')).not.toContain('getNitroPreset');
+  });
 
-    it("does NOT call copyAdapters", () => {
-        expect(readSrc("cli/build.ts")).not.toContain("copyAdapters");
-    });
+  it('does NOT call copyAdapters', () => {
+    expect(readSrc('cli/build.ts')).not.toContain('copyAdapters');
+  });
 });
 
 // ─── deploy.ts: no Nitro build orchestration ──────────────────────────────────
 
-describe("deploy.ts: no Nitro build orchestration", () => {
-    it("does NOT contain NITRO_PRESET env var", () => {
-        expect(readSrc("cli/deploy.ts")).not.toMatch(/NITRO_PRESET/);
-    });
+describe('deploy.ts: no Nitro build orchestration', () => {
+  it('does NOT contain NITRO_PRESET env var', () => {
+    expect(readSrc('cli/deploy.ts')).not.toMatch(/NITRO_PRESET/);
+  });
 
-    it("does NOT call getNitroPreset", () => {
-        expect(readSrc("cli/deploy.ts")).not.toContain("getNitroPreset");
-    });
+  it('does NOT call getNitroPreset', () => {
+    expect(readSrc('cli/deploy.ts')).not.toContain('getNitroPreset');
+  });
 
-    it("does NOT call copyAdapters", () => {
-        expect(readSrc("cli/deploy.ts")).not.toContain("copyAdapters");
-    });
+  it('does NOT call copyAdapters', () => {
+    expect(readSrc('cli/deploy.ts')).not.toContain('copyAdapters');
+  });
 });
 
 // ─── node-server.ts: standalone runtime, not Nitro ───────────────────────────
 
-describe("node-server.ts: starts Next.js standalone server, not Nitro", () => {
-    it("does NOT import Nitro server (index.mjs / .output/server)", () => {
-        const src = readSrc("adapters/node-server.ts");
-        expect(src).not.toContain("index.mjs");
-        expect(src).not.toContain(".output/server");
-    });
+describe('node-server.ts: starts Next.js standalone server, not Nitro', () => {
+  it('does NOT import Nitro server (index.mjs / .output/server)', () => {
+    const src = readSrc('adapters/node-server.ts');
+    expect(src).not.toContain('index.mjs');
+    expect(src).not.toContain('.output/server');
+  });
 
-    it("references the Next.js standalone server.js entry point", () => {
-        expect(readSrc("adapters/node-server.ts")).toMatch(/server\.js/);
-    });
+  it('references the Next.js standalone server.js entry point', () => {
+    expect(readSrc('adapters/node-server.ts')).toMatch(/server\.js/);
+  });
 });
 
 // ─── config.ts: runtime field is standalone-oriented, not Nitro ──────────────
 
-describe("config.ts: runtime field describes standalone, not Nitro preset", () => {
-    it('does NOT describe runtime as a "Nitro preset"', () => {
-        expect(readSrc("config.ts")).not.toMatch(/Nitro preset/i);
-    });
+describe('config.ts: runtime field describes standalone, not Nitro preset', () => {
+  it('does NOT describe runtime as a "Nitro preset"', () => {
+    expect(readSrc('config.ts')).not.toMatch(/Nitro preset/i);
+  });
 });
 
 // ─── apps/file-manager: no regression on the official adapter ─────────────────
 // The app already uses the official NextAdapter via experimental.adapterPath.
 // Verify the next-adapter.ts and next.config.ts remain on that path.
 
-describe("apps/file-manager: official adapter, not Nitro", () => {
-    const APP_SRC = resolve(TESTS_DIR, "../../../../apps/file-manager");
+// ─── node-server: NODE_COMPILE_CACHE forwarded to spawned process ─────────────
+// `buildChildEnv` is extracted from node-server.ts so it can be tested without
+// starting the HTTP server or spawning a real child process.
+// The operator injects NODE_COMPILE_CACHE pointing at a PVC for cross-pod caching;
+// the standalone server MUST inherit it — never hardcode or override it.
 
-    function readApp(relPath: string): string {
-        return readFileSync(resolve(APP_SRC, relPath), "utf-8");
+describe('node-server: NODE_COMPILE_CACHE forwarded to spawned server', () => {
+  it('buildChildEnv inherits NODE_COMPILE_CACHE from process.env when set', async () => {
+    const { buildChildEnv } = await import('../adapters/env');
+    const saved = process.env.NODE_COMPILE_CACHE;
+    try {
+      process.env.NODE_COMPILE_CACHE = '/test/compile-cache';
+      expect(buildChildEnv().NODE_COMPILE_CACHE).toBe('/test/compile-cache');
+    } finally {
+      if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
+      else process.env.NODE_COMPILE_CACHE = saved;
     }
+  });
 
-    it("next-adapter.ts uses official NextAdapter interface (not Nitro)", () => {
-        const src = readApp("next-adapter.ts");
-        // Must import NextAdapter from 'next'
-        expect(src).toMatch(/from\s+['"]next['"]/);
-        // Must not use Nitro-style imports
-        expect(src).not.toContain("index.mjs");
-    });
+  it('externally-set NODE_COMPILE_CACHE is not clobbered (operator PVC path wins)', async () => {
+    const { buildChildEnv } = await import('../adapters/env');
+    const saved = process.env.NODE_COMPILE_CACHE;
+    try {
+      process.env.NODE_COMPILE_CACHE = '/operator-pvc/bytecode-cache';
+      const env = buildChildEnv();
+      expect(env.NODE_COMPILE_CACHE).toBe('/operator-pvc/bytecode-cache');
+    } finally {
+      if (saved === undefined) delete process.env.NODE_COMPILE_CACHE;
+      else process.env.NODE_COMPILE_CACHE = saved;
+    }
+  });
 
-    it("next.config.ts sets output:standalone and adapterPath (official adapter)", () => {
-        const src = readApp("next.config.ts");
-        expect(src).toContain("output: 'standalone'");
-        expect(src).toContain("adapterPath");
-    });
+  it('NODE_COMPILE_CACHE absent from env when not set (no hardcoded fallback in buildChildEnv)', async () => {
+    const { buildChildEnv } = await import('../adapters/env');
+    const saved = process.env.NODE_COMPILE_CACHE;
+    try {
+      delete process.env.NODE_COMPILE_CACHE;
+      // Must be undefined — the Dockerfile CMD supplies the fallback, not the code
+      expect(buildChildEnv().NODE_COMPILE_CACHE).toBeUndefined();
+    } finally {
+      if (saved !== undefined) process.env.NODE_COMPILE_CACHE = saved;
+    }
+  });
+});
+
+// ─── apps/file-manager: no regression on the official adapter ─────────────────
+// The app already uses the official NextAdapter via experimental.adapterPath.
+// Verify the next-adapter.ts and next.config.ts remain on that path.
+
+describe('apps/file-manager: official adapter, not Nitro', () => {
+  const APP_SRC = resolve(TESTS_DIR, '../../../../apps/file-manager');
+
+  function readApp(relPath: string): string {
+    return readFileSync(resolve(APP_SRC, relPath), 'utf-8');
+  }
+
+  it('next-adapter.ts uses official NextAdapter interface (not Nitro)', () => {
+    const src = readApp('next-adapter.ts');
+    // Must import NextAdapter from 'next'
+    expect(src).toMatch(/from\s+['"]next['"]/);
+    // Must not use Nitro-style imports
+    expect(src).not.toContain('index.mjs');
+  });
+
+  it('next.config.ts sets output:standalone and adapterPath (official adapter)', () => {
+    const src = readApp('next.config.ts');
+    expect(src).toContain("output: 'standalone'");
+    expect(src).toContain('adapterPath');
+  });
 });

--- a/packages/kn-next/src/adapters/env.ts
+++ b/packages/kn-next/src/adapters/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the environment object for the spawned Next.js standalone server.
+ *
+ * All process.env vars (including NODE_COMPILE_CACHE) are inherited via spread.
+ * The operator may inject NODE_COMPILE_CACHE pointing at a shared PVC for
+ * cross-cold-start bytecode caching — we MUST NOT hardcode or override it here.
+ * The Dockerfile CMD supplies a fallback when the env var is unset at runtime.
+ *
+ * Exported separately so tests can assert forwarding without starting the server
+ * or spawning a real child process.
+ */
+export function buildChildEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PORT: process.env.PORT ?? '3000',
+    ...overrides,
+  };
+}

--- a/packages/kn-next/src/adapters/env.ts
+++ b/packages/kn-next/src/adapters/env.ts
@@ -9,10 +9,12 @@
  * Exported separately so tests can assert forwarding without starting the server
  * or spawning a real child process.
  */
-export function buildChildEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    PORT: process.env.PORT ?? '3000',
-    ...overrides,
-  };
+export function buildChildEnv(
+    overrides: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+    return {
+        ...process.env,
+        PORT: process.env.PORT ?? "3000",
+        ...overrides,
+    };
 }

--- a/packages/kn-next/src/adapters/node-server.ts
+++ b/packages/kn-next/src/adapters/node-server.ts
@@ -14,13 +14,14 @@
  * vinext → official Next.js Adapter migration.
  */
 
-import { spawn } from "node:child_process";
-import http from "node:http";
-import { resolve } from "node:path";
-import { collectDefaultMetrics, Registry } from "prom-client";
-import { createLogger } from "../utils/logger";
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { resolve } from 'node:path';
+import { collectDefaultMetrics, Registry } from 'prom-client';
+import { buildChildEnv } from './env';
+import { createLogger } from '../utils/logger';
 
-const log = createLogger({ module: "server" });
+const log = createLogger({ module: 'server' });
 const METRICS_PORT = 9091;
 
 // ── Prometheus metrics server on :9091 ────────────────────────────────────────
@@ -29,54 +30,54 @@ const metricsRegistry = new Registry();
 collectDefaultMetrics({ register: metricsRegistry });
 
 const metricsServer = http.createServer(async (req, res) => {
-    if (req.url === "/metrics" && req.method === "GET") {
-        res.setHeader("Content-Type", metricsRegistry.contentType);
-        const metrics = await metricsRegistry.metrics();
-        res.end(metrics);
-        return;
-    }
-    res.writeHead(404);
-    res.end("Not Found");
+  if (req.url === '/metrics' && req.method === 'GET') {
+    res.setHeader('Content-Type', metricsRegistry.contentType);
+    const metrics = await metricsRegistry.metrics();
+    res.end(metrics);
+    return;
+  }
+  res.writeHead(404);
+  res.end('Not Found');
 });
 
 metricsServer.listen(METRICS_PORT, () => {
-    log.info({ port: METRICS_PORT }, "Prometheus metrics server started");
+  log.info({ port: METRICS_PORT }, 'Prometheus metrics server started');
 });
 
 // ── Next.js standalone server ─────────────────────────────────────────────────
 // `next build` with output:'standalone' emits server.js in .next/standalone/.
 // We spawn it as a child process so SIGTERM can drain it cleanly before we exit.
 const serverJs = resolve(
-    process.cwd(),
-    process.env.STANDALONE_SERVER_PATH ?? ".next/standalone/server.js",
+  process.cwd(),
+  process.env.STANDALONE_SERVER_PATH ?? '.next/standalone/server.js',
 );
 
-log.info({ serverJs }, "Starting Next.js standalone server");
+log.info({ serverJs }, 'Starting Next.js standalone server');
 
 const nextProc = spawn(process.execPath, [serverJs], {
-    stdio: "inherit",
-    env: { ...process.env, PORT: process.env.PORT ?? "3000" },
+  stdio: 'inherit',
+  env: buildChildEnv(),
 });
 
-nextProc.on("error", (err) => {
-    log.fatal({ err }, "Failed to start Next.js standalone server");
-    process.exit(1);
+nextProc.on('error', (err) => {
+  log.fatal({ err }, 'Failed to start Next.js standalone server');
+  process.exit(1);
 });
 
-nextProc.on("exit", (code, signal) => {
-    log.info({ code, signal }, "Next.js standalone server exited");
-    metricsServer.close();
-    process.exit(code ?? 0);
+nextProc.on('exit', (code, signal) => {
+  log.info({ code, signal }, 'Next.js standalone server exited');
+  metricsServer.close();
+  process.exit(code ?? 0);
 });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 const shutdown = (signal: string) => {
-    log.info({ signal }, "Shutting down gracefully...");
-    metricsServer.close();
-    nextProc.kill("SIGTERM");
-    // Give the child process time to drain in-flight requests before we exit.
-    setTimeout(() => process.exit(0), 5000).unref();
+  log.info({ signal }, 'Shutting down gracefully...');
+  metricsServer.close();
+  nextProc.kill('SIGTERM');
+  // Give the child process time to drain in-flight requests before we exit.
+  setTimeout(() => process.exit(0), 5000).unref();
 };
 
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/packages/kn-next/src/adapters/node-server.ts
+++ b/packages/kn-next/src/adapters/node-server.ts
@@ -1,47 +1,82 @@
-import http from "node:http";
-import { collectDefaultMetrics, Registry } from "prom-client";
-import { createLogger } from "../utils/logger";
+/**
+ * Knative runtime entry for the Next.js standalone server.
+ *
+ * Responsibilities:
+ *  1. Expose Prometheus metrics on :9091 (sidecar pattern — separate port from app).
+ *  2. Spawn the Next.js standalone server.js produced by `next build` with
+ *     output:'standalone'. The standalone server self-starts on $PORT (default 3000).
+ *
+ * The standalone server path can be overridden via STANDALONE_SERVER_PATH env var.
+ * Default: ".next/standalone/server.js" (single-app repo).
+ * Monorepo example: ".next/standalone/apps/file-manager/server.js"
+ *
+ * NOTE: The previous Nitro runtime entry was removed in the
+ * vinext → official Next.js Adapter migration.
+ */
 
-const log = createLogger({ module: "server" });
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { collectDefaultMetrics, Registry } from 'prom-client';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger({ module: 'server' });
 const METRICS_PORT = 9091;
 
-// Prometheus registry — collects default Node.js process metrics
+// ── Prometheus metrics server on :9091 ────────────────────────────────────────
+// Clean separation: Next.js standalone owns $PORT (3000), metrics owns 9091.
 const metricsRegistry = new Registry();
 collectDefaultMetrics({ register: metricsRegistry });
 
-// Start a dedicated metrics server on port 9091.
-// Clean separation: Nitro owns :3000, metrics owns :9091.
 const metricsServer = http.createServer(async (req, res) => {
-    if (req.url === "/metrics" && req.method === "GET") {
-        res.setHeader("Content-Type", metricsRegistry.contentType);
-        const metrics = await metricsRegistry.metrics();
-        res.end(metrics);
-        return;
-    }
-    res.writeHead(404);
-    res.end("Not Found");
+  if (req.url === '/metrics' && req.method === 'GET') {
+    res.setHeader('Content-Type', metricsRegistry.contentType);
+    const metrics = await metricsRegistry.metrics();
+    res.end(metrics);
+    return;
+  }
+  res.writeHead(404);
+  res.end('Not Found');
 });
 
 metricsServer.listen(METRICS_PORT, () => {
-    log.info({ port: METRICS_PORT }, "Prometheus metrics server started");
+  log.info({ port: METRICS_PORT }, 'Prometheus metrics server started');
 });
 
-try {
-    // Import Nitro server — it self-starts on :3000
-    // @ts-expect-error — Nitro server entry exists at runtime in .output/server/index.mjs
-    await import("../server/index.mjs");
-    log.info("Nitro server listening on :3000");
-} catch (err) {
-    log.fatal({ err }, "Server startup failed");
-    process.exit(1);
-}
+// ── Next.js standalone server ─────────────────────────────────────────────────
+// `next build` with output:'standalone' emits server.js in .next/standalone/.
+// We spawn it as a child process so SIGTERM can drain it cleanly before we exit.
+const serverJs = resolve(
+  process.cwd(),
+  process.env.STANDALONE_SERVER_PATH ?? '.next/standalone/server.js',
+);
 
-// Handle graceful shutdown
-const shutdown = () => {
-    log.info("Shutting down gracefully...");
-    metricsServer.close();
-    process.exit(0);
+log.info({ serverJs }, 'Starting Next.js standalone server');
+
+const nextProc = spawn(process.execPath, [serverJs], {
+  stdio: 'inherit',
+  env: { ...process.env, PORT: process.env.PORT ?? '3000' },
+});
+
+nextProc.on('error', (err) => {
+  log.fatal({ err }, 'Failed to start Next.js standalone server');
+  process.exit(1);
+});
+
+nextProc.on('exit', (code, signal) => {
+  log.info({ code, signal }, 'Next.js standalone server exited');
+  metricsServer.close();
+  process.exit(code ?? 0);
+});
+
+// ── Graceful shutdown ─────────────────────────────────────────────────────────
+const shutdown = (signal: string) => {
+  log.info({ signal }, 'Shutting down gracefully...');
+  metricsServer.close();
+  nextProc.kill('SIGTERM');
+  // Give the child process time to drain in-flight requests before we exit.
+  setTimeout(() => process.exit(0), 5000).unref();
 };
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/packages/kn-next/src/adapters/node-server.ts
+++ b/packages/kn-next/src/adapters/node-server.ts
@@ -14,13 +14,13 @@
  * vinext → official Next.js Adapter migration.
  */
 
-import http from 'node:http';
-import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
-import { collectDefaultMetrics, Registry } from 'prom-client';
-import { createLogger } from '../utils/logger';
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { resolve } from "node:path";
+import { collectDefaultMetrics, Registry } from "prom-client";
+import { createLogger } from "../utils/logger";
 
-const log = createLogger({ module: 'server' });
+const log = createLogger({ module: "server" });
 const METRICS_PORT = 9091;
 
 // ── Prometheus metrics server on :9091 ────────────────────────────────────────
@@ -29,54 +29,54 @@ const metricsRegistry = new Registry();
 collectDefaultMetrics({ register: metricsRegistry });
 
 const metricsServer = http.createServer(async (req, res) => {
-  if (req.url === '/metrics' && req.method === 'GET') {
-    res.setHeader('Content-Type', metricsRegistry.contentType);
-    const metrics = await metricsRegistry.metrics();
-    res.end(metrics);
-    return;
-  }
-  res.writeHead(404);
-  res.end('Not Found');
+    if (req.url === "/metrics" && req.method === "GET") {
+        res.setHeader("Content-Type", metricsRegistry.contentType);
+        const metrics = await metricsRegistry.metrics();
+        res.end(metrics);
+        return;
+    }
+    res.writeHead(404);
+    res.end("Not Found");
 });
 
 metricsServer.listen(METRICS_PORT, () => {
-  log.info({ port: METRICS_PORT }, 'Prometheus metrics server started');
+    log.info({ port: METRICS_PORT }, "Prometheus metrics server started");
 });
 
 // ── Next.js standalone server ─────────────────────────────────────────────────
 // `next build` with output:'standalone' emits server.js in .next/standalone/.
 // We spawn it as a child process so SIGTERM can drain it cleanly before we exit.
 const serverJs = resolve(
-  process.cwd(),
-  process.env.STANDALONE_SERVER_PATH ?? '.next/standalone/server.js',
+    process.cwd(),
+    process.env.STANDALONE_SERVER_PATH ?? ".next/standalone/server.js",
 );
 
-log.info({ serverJs }, 'Starting Next.js standalone server');
+log.info({ serverJs }, "Starting Next.js standalone server");
 
 const nextProc = spawn(process.execPath, [serverJs], {
-  stdio: 'inherit',
-  env: { ...process.env, PORT: process.env.PORT ?? '3000' },
+    stdio: "inherit",
+    env: { ...process.env, PORT: process.env.PORT ?? "3000" },
 });
 
-nextProc.on('error', (err) => {
-  log.fatal({ err }, 'Failed to start Next.js standalone server');
-  process.exit(1);
+nextProc.on("error", (err) => {
+    log.fatal({ err }, "Failed to start Next.js standalone server");
+    process.exit(1);
 });
 
-nextProc.on('exit', (code, signal) => {
-  log.info({ code, signal }, 'Next.js standalone server exited');
-  metricsServer.close();
-  process.exit(code ?? 0);
+nextProc.on("exit", (code, signal) => {
+    log.info({ code, signal }, "Next.js standalone server exited");
+    metricsServer.close();
+    process.exit(code ?? 0);
 });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 const shutdown = (signal: string) => {
-  log.info({ signal }, 'Shutting down gracefully...');
-  metricsServer.close();
-  nextProc.kill('SIGTERM');
-  // Give the child process time to drain in-flight requests before we exit.
-  setTimeout(() => process.exit(0), 5000).unref();
+    log.info({ signal }, "Shutting down gracefully...");
+    metricsServer.close();
+    nextProc.kill("SIGTERM");
+    // Give the child process time to drain in-flight requests before we exit.
+    setTimeout(() => process.exit(0), 5000).unref();
 };
 
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/packages/kn-next/src/adapters/node-server.ts
+++ b/packages/kn-next/src/adapters/node-server.ts
@@ -14,14 +14,14 @@
  * vinext → official Next.js Adapter migration.
  */
 
-import { spawn } from 'node:child_process';
-import http from 'node:http';
-import { resolve } from 'node:path';
-import { collectDefaultMetrics, Registry } from 'prom-client';
-import { buildChildEnv } from './env';
-import { createLogger } from '../utils/logger';
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { resolve } from "node:path";
+import { collectDefaultMetrics, Registry } from "prom-client";
+import { createLogger } from "../utils/logger";
+import { buildChildEnv } from "./env";
 
-const log = createLogger({ module: 'server' });
+const log = createLogger({ module: "server" });
 const METRICS_PORT = 9091;
 
 // ── Prometheus metrics server on :9091 ────────────────────────────────────────
@@ -30,54 +30,54 @@ const metricsRegistry = new Registry();
 collectDefaultMetrics({ register: metricsRegistry });
 
 const metricsServer = http.createServer(async (req, res) => {
-  if (req.url === '/metrics' && req.method === 'GET') {
-    res.setHeader('Content-Type', metricsRegistry.contentType);
-    const metrics = await metricsRegistry.metrics();
-    res.end(metrics);
-    return;
-  }
-  res.writeHead(404);
-  res.end('Not Found');
+    if (req.url === "/metrics" && req.method === "GET") {
+        res.setHeader("Content-Type", metricsRegistry.contentType);
+        const metrics = await metricsRegistry.metrics();
+        res.end(metrics);
+        return;
+    }
+    res.writeHead(404);
+    res.end("Not Found");
 });
 
 metricsServer.listen(METRICS_PORT, () => {
-  log.info({ port: METRICS_PORT }, 'Prometheus metrics server started');
+    log.info({ port: METRICS_PORT }, "Prometheus metrics server started");
 });
 
 // ── Next.js standalone server ─────────────────────────────────────────────────
 // `next build` with output:'standalone' emits server.js in .next/standalone/.
 // We spawn it as a child process so SIGTERM can drain it cleanly before we exit.
 const serverJs = resolve(
-  process.cwd(),
-  process.env.STANDALONE_SERVER_PATH ?? '.next/standalone/server.js',
+    process.cwd(),
+    process.env.STANDALONE_SERVER_PATH ?? ".next/standalone/server.js",
 );
 
-log.info({ serverJs }, 'Starting Next.js standalone server');
+log.info({ serverJs }, "Starting Next.js standalone server");
 
 const nextProc = spawn(process.execPath, [serverJs], {
-  stdio: 'inherit',
-  env: buildChildEnv(),
+    stdio: "inherit",
+    env: buildChildEnv(),
 });
 
-nextProc.on('error', (err) => {
-  log.fatal({ err }, 'Failed to start Next.js standalone server');
-  process.exit(1);
+nextProc.on("error", (err) => {
+    log.fatal({ err }, "Failed to start Next.js standalone server");
+    process.exit(1);
 });
 
-nextProc.on('exit', (code, signal) => {
-  log.info({ code, signal }, 'Next.js standalone server exited');
-  metricsServer.close();
-  process.exit(code ?? 0);
+nextProc.on("exit", (code, signal) => {
+    log.info({ code, signal }, "Next.js standalone server exited");
+    metricsServer.close();
+    process.exit(code ?? 0);
 });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 const shutdown = (signal: string) => {
-  log.info({ signal }, 'Shutting down gracefully...');
-  metricsServer.close();
-  nextProc.kill('SIGTERM');
-  // Give the child process time to drain in-flight requests before we exit.
-  setTimeout(() => process.exit(0), 5000).unref();
+    log.info({ signal }, "Shutting down gracefully...");
+    metricsServer.close();
+    nextProc.kill("SIGTERM");
+    // Give the child process time to drain in-flight requests before we exit.
+    setTimeout(() => process.exit(0), 5000).unref();
 };
 
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/packages/kn-next/src/cli/build.ts
+++ b/packages/kn-next/src/cli/build.ts
@@ -1,96 +1,93 @@
 #!/usr/bin/env bun
 /**
- * kn-next build - Prepares Next.js app for Knative deployment using Vinext
+ * kn-next build — Prepares Next.js app for Knative deployment.
  *
  * Usage:
  *   bun run packages/kn-next/src/cli/build.ts
  *
  * Steps:
  *   1. Load kn-next.config.ts (with validation)
- *   2. Run Vinext build via Nitro (preset from config.runtime)
- *   3. Upload static assets to storage (GCS/S3)
- *   4. Copy adapters to dist
- *   5. Generate knative-service.yaml
+ *   2. Run `next build` (output:'standalone' set in the app's next.config.ts)
+ *   3. Upload static assets to storage (GCS/S3/MinIO)
+ *   4. Generate knative-service.yaml
+ *
+ * NOTE: The Vinext/Nitro build orchestration was removed in the official
+ * Next.js Adapter migration. The CLI now delegates to the project's
+ * `npm run build` script which runs `next build` with output:'standalone'.
  */
 
-import { join } from "node:path";
-import { $ } from "bun";
-import { generateKnativeManifest } from "../generators/knative-manifest";
-import { uploadAssets } from "../utils/asset-upload";
-import { createLogger } from "../utils/logger";
-import { copyAdapters, getNitroPreset, loadConfig } from "./shared";
+import { join } from 'node:path';
+import { $ } from 'bun';
+import { generateKnativeManifest } from '../generators/knative-manifest';
+import { uploadAssets } from '../utils/asset-upload';
+import { createLogger } from '../utils/logger';
+import { loadConfig } from './shared';
 
-const log = createLogger({ module: "build" });
+const log = createLogger({ module: 'build' });
 
 interface BuildOptions {
-    enableKafkaQueue?: boolean;
-    skipNextBuild?: boolean;
+  enableKafkaQueue?: boolean;
+  skipNextBuild?: boolean;
 }
 
 export async function build(options: BuildOptions = {}) {
-    log.info("🔨 kn-next build (Vinext + Nitro)");
+  log.info('🔨 kn-next build (Next.js official adapter + standalone)');
 
-    const workDir = process.cwd();
-    const outputDir = join(workDir, ".output");
+  const workDir = process.cwd();
+  const outputDir = join(workDir, '.output');
 
-    // 1. Load config (validates at load time)
-    log.info("Loading configuration...");
-    const config = await loadConfig();
-    log.info(
-        {
-            app: config.name,
-            storage: `${config.storage.provider} (${config.storage.bucket})`,
-            cache: config.cache?.provider ?? "none",
-            runtime: config.runtime ?? "bun",
-        },
-        "Configuration loaded",
-    );
+  // 1. Load config (validates at load time)
+  log.info('Loading configuration...');
+  const config = await loadConfig();
+  log.info(
+    {
+      app: config.name,
+      storage: `${config.storage.provider} (${config.storage.bucket})`,
+      cache: config.cache?.provider ?? 'none',
+      runtime: config.runtime ?? 'node',
+    },
+    'Configuration loaded',
+  );
 
-    // 2. Run Vinext build with the correct Nitro preset from config
-    if (!options.skipNextBuild) {
-        const preset = getNitroPreset(config);
-        log.info({ preset }, "Building Vinext app with Nitro");
-        await $`NITRO_PRESET=${preset} npm run build`.quiet();
-        log.info("Vinext build complete");
-    }
+  // 2. Run `next build` via the project's build script.
+  //    The app's next.config.ts must set output:'standalone'.
+  if (!options.skipNextBuild) {
+    log.info('Running next build (output:standalone)...');
+    await $`npm run build`.quiet();
+    log.info('Next.js build complete — standalone output in .next/standalone/');
+  }
 
-    // 3. Upload static assets
-    log.info("Uploading static assets...");
-    await uploadAssets(config);
-    log.info("Assets uploaded");
+  // 3. Upload static assets
+  log.info('Uploading static assets...');
+  await uploadAssets(config);
+  log.info('Assets uploaded');
 
-    // 4. Copy adapters
-    log.info("Copying adapters...");
-    await copyAdapters(outputDir);
+  // 4. Generate Knative manifest
+  log.info('Generating Knative manifest...');
+  generateKnativeManifest({
+    config,
+    outputDir,
+    enableKafkaQueue: options.enableKafkaQueue,
+  });
 
-    // 5. Generate Knative manifest
-    log.info("Generating Knative manifest...");
-    generateKnativeManifest({
-        config,
-        outputDir,
-        enableKafkaQueue: options.enableKafkaQueue,
-    });
-
-    log.info(
-        {
-            output: outputDir,
-            manifest: join(outputDir, "knative-service.yaml"),
-        },
-        "✨ Build complete!",
-    );
+  log.info(
+    {
+      output: outputDir,
+      manifest: join(outputDir, 'knative-service.yaml'),
+    },
+    '✨ Build complete!',
+  );
 }
 
 // Run if executed directly
 if (import.meta.main) {
-    try {
-        await build({
-            enableKafkaQueue: process.argv.includes("--no-kafka")
-                ? false
-                : undefined,
-            skipNextBuild: process.argv.includes("--skip-next"),
-        });
-    } catch (err) {
-        log.fatal({ err }, "Build failed");
-        process.exit(1);
-    }
+  try {
+    await build({
+      enableKafkaQueue: process.argv.includes('--no-kafka') ? false : undefined,
+      skipNextBuild: process.argv.includes('--skip-next'),
+    });
+  } catch (err) {
+    log.fatal({ err }, 'Build failed');
+    process.exit(1);
+  }
 }

--- a/packages/kn-next/src/cli/build.ts
+++ b/packages/kn-next/src/cli/build.ts
@@ -16,78 +16,82 @@
  * `npm run build` script which runs `next build` with output:'standalone'.
  */
 
-import { join } from 'node:path';
-import { $ } from 'bun';
-import { generateKnativeManifest } from '../generators/knative-manifest';
-import { uploadAssets } from '../utils/asset-upload';
-import { createLogger } from '../utils/logger';
-import { loadConfig } from './shared';
+import { join } from "node:path";
+import { $ } from "bun";
+import { generateKnativeManifest } from "../generators/knative-manifest";
+import { uploadAssets } from "../utils/asset-upload";
+import { createLogger } from "../utils/logger";
+import { loadConfig } from "./shared";
 
-const log = createLogger({ module: 'build' });
+const log = createLogger({ module: "build" });
 
 interface BuildOptions {
-  enableKafkaQueue?: boolean;
-  skipNextBuild?: boolean;
+    enableKafkaQueue?: boolean;
+    skipNextBuild?: boolean;
 }
 
 export async function build(options: BuildOptions = {}) {
-  log.info('🔨 kn-next build (Next.js official adapter + standalone)');
+    log.info("🔨 kn-next build (Next.js official adapter + standalone)");
 
-  const workDir = process.cwd();
-  const outputDir = join(workDir, '.output');
+    const workDir = process.cwd();
+    const outputDir = join(workDir, ".output");
 
-  // 1. Load config (validates at load time)
-  log.info('Loading configuration...');
-  const config = await loadConfig();
-  log.info(
-    {
-      app: config.name,
-      storage: `${config.storage.provider} (${config.storage.bucket})`,
-      cache: config.cache?.provider ?? 'none',
-      runtime: config.runtime ?? 'node',
-    },
-    'Configuration loaded',
-  );
+    // 1. Load config (validates at load time)
+    log.info("Loading configuration...");
+    const config = await loadConfig();
+    log.info(
+        {
+            app: config.name,
+            storage: `${config.storage.provider} (${config.storage.bucket})`,
+            cache: config.cache?.provider ?? "none",
+            runtime: config.runtime ?? "node",
+        },
+        "Configuration loaded",
+    );
 
-  // 2. Run `next build` via the project's build script.
-  //    The app's next.config.ts must set output:'standalone'.
-  if (!options.skipNextBuild) {
-    log.info('Running next build (output:standalone)...');
-    await $`npm run build`.quiet();
-    log.info('Next.js build complete — standalone output in .next/standalone/');
-  }
+    // 2. Run `next build` via the project's build script.
+    //    The app's next.config.ts must set output:'standalone'.
+    if (!options.skipNextBuild) {
+        log.info("Running next build (output:standalone)...");
+        await $`npm run build`.quiet();
+        log.info(
+            "Next.js build complete — standalone output in .next/standalone/",
+        );
+    }
 
-  // 3. Upload static assets
-  log.info('Uploading static assets...');
-  await uploadAssets(config);
-  log.info('Assets uploaded');
+    // 3. Upload static assets
+    log.info("Uploading static assets...");
+    await uploadAssets(config);
+    log.info("Assets uploaded");
 
-  // 4. Generate Knative manifest
-  log.info('Generating Knative manifest...');
-  generateKnativeManifest({
-    config,
-    outputDir,
-    enableKafkaQueue: options.enableKafkaQueue,
-  });
+    // 4. Generate Knative manifest
+    log.info("Generating Knative manifest...");
+    generateKnativeManifest({
+        config,
+        outputDir,
+        enableKafkaQueue: options.enableKafkaQueue,
+    });
 
-  log.info(
-    {
-      output: outputDir,
-      manifest: join(outputDir, 'knative-service.yaml'),
-    },
-    '✨ Build complete!',
-  );
+    log.info(
+        {
+            output: outputDir,
+            manifest: join(outputDir, "knative-service.yaml"),
+        },
+        "✨ Build complete!",
+    );
 }
 
 // Run if executed directly
 if (import.meta.main) {
-  try {
-    await build({
-      enableKafkaQueue: process.argv.includes('--no-kafka') ? false : undefined,
-      skipNextBuild: process.argv.includes('--skip-next'),
-    });
-  } catch (err) {
-    log.fatal({ err }, 'Build failed');
-    process.exit(1);
-  }
+    try {
+        await build({
+            enableKafkaQueue: process.argv.includes("--no-kafka")
+                ? false
+                : undefined,
+            skipNextBuild: process.argv.includes("--skip-next"),
+        });
+    } catch (err) {
+        log.fatal({ err }, "Build failed");
+        process.exit(1);
+    }
 }

--- a/packages/kn-next/src/cli/deploy.ts
+++ b/packages/kn-next/src/cli/deploy.ts
@@ -1,190 +1,184 @@
 #!/usr/bin/env bun
 /**
- * kn-next CLI - Knative Next.js Deployment Automation (Vinext)
+ * kn-next CLI — Knative Next.js Deployment Automation
  *
  * Usage:
  *   npx kn-next deploy [options]
+ *
+ * NOTE: The Vinext/Nitro build orchestration was removed in the official
+ * Next.js Adapter migration. The CLI now delegates to the project's
+ * `npm run build` script which runs `next build` with output:'standalone'.
  */
 
-import { join, resolve } from "node:path";
-import { parseArgs } from "node:util";
-import { $ } from "bun";
-import type { KnativeNextConfig } from "../config";
-import { generateInfrastructure } from "../generators/infrastructure";
-import { generateKnativeManifest } from "../generators/knative-manifest";
-import { getAssetPrefix, uploadAssets } from "../utils/asset-upload";
-import { createLogger } from "../utils/logger";
-import { copyAdapters, getNitroPreset, loadConfig } from "./shared";
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { $ } from 'bun';
+import type { KnativeNextConfig } from '../config';
+import { generateInfrastructure } from '../generators/infrastructure';
+import { generateKnativeManifest } from '../generators/knative-manifest';
+import { getAssetPrefix, uploadAssets } from '../utils/asset-upload';
+import { createLogger } from '../utils/logger';
+import { loadConfig } from './shared';
 
-const log = createLogger({ module: "deploy" });
+const log = createLogger({ module: 'deploy' });
 
 interface DeployOptions {
-    registry?: string;
-    bucket?: string;
-    tag?: string;
-    namespace: string;
-    skipBuild: boolean;
-    skipUpload: boolean;
-    skipInfra: boolean;
-    dryRun: boolean;
+  registry?: string;
+  bucket?: string;
+  tag?: string;
+  namespace: string;
+  skipBuild: boolean;
+  skipUpload: boolean;
+  skipInfra: boolean;
+  dryRun: boolean;
 }
 
 function parseCliArgs(): DeployOptions {
-    const { values } = parseArgs({
-        options: {
-            registry: { type: "string", short: "r" },
-            bucket: { type: "string", short: "b" },
-            tag: { type: "string", short: "t" },
-            namespace: { type: "string", short: "n", default: "default" },
-            "skip-build": { type: "boolean", default: false },
-            "skip-upload": { type: "boolean", default: false },
-            "skip-infra": { type: "boolean", default: false },
-            "dry-run": { type: "boolean", default: false },
-            help: { type: "boolean", short: "h", default: false },
-        },
-        strict: true,
-        allowPositionals: true,
-    });
+  const { values } = parseArgs({
+    options: {
+      registry: { type: 'string', short: 'r' },
+      bucket: { type: 'string', short: 'b' },
+      tag: { type: 'string', short: 't' },
+      namespace: { type: 'string', short: 'n', default: 'default' },
+      'skip-build': { type: 'boolean', default: false },
+      'skip-upload': { type: 'boolean', default: false },
+      'skip-infra': { type: 'boolean', default: false },
+      'dry-run': { type: 'boolean', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
 
-    if (values.help) {
-        log.info("Help output omitted for brevity");
-        process.exit(0);
-    }
+  if (values.help) {
+    log.info('Help output omitted for brevity');
+    process.exit(0);
+  }
 
-    return {
-        registry: values.registry || process.env.KN_REGISTRY,
-        bucket: values.bucket || process.env.KN_BUCKET,
-        tag: values.tag || process.env.KN_IMAGE_TAG,
-        namespace: values.namespace || process.env.KN_NAMESPACE || "default",
-        skipBuild: values["skip-build"] ?? false,
-        skipUpload: values["skip-upload"] ?? false,
-        skipInfra: values["skip-infra"] ?? false,
-        dryRun: values["dry-run"] ?? false,
-    };
+  return {
+    registry: values.registry || process.env.KN_REGISTRY,
+    bucket: values.bucket || process.env.KN_BUCKET,
+    tag: values.tag || process.env.KN_IMAGE_TAG,
+    namespace: values.namespace || process.env.KN_NAMESPACE || 'default',
+    skipBuild: values['skip-build'] ?? false,
+    skipUpload: values['skip-upload'] ?? false,
+    skipInfra: values['skip-infra'] ?? false,
+    dryRun: values['dry-run'] ?? false,
+  };
 }
 
-function applyOverrides(
-    config: KnativeNextConfig,
-    options: DeployOptions,
-): KnativeNextConfig {
-    const overridden = { ...config };
+function applyOverrides(config: KnativeNextConfig, options: DeployOptions): KnativeNextConfig {
+  const overridden = { ...config };
 
-    if (options.registry) {
-        overridden.registry = options.registry;
-    }
-    if (options.bucket) {
-        overridden.storage = { ...overridden.storage, bucket: options.bucket };
-    }
+  if (options.registry) {
+    overridden.registry = options.registry;
+  }
+  if (options.bucket) {
+    overridden.storage = { ...overridden.storage, bucket: options.bucket };
+  }
 
-    if (process.env.KN_REDIS_URL && overridden.cache?.provider === "redis") {
-        overridden.cache = {
-            ...overridden.cache,
-            url: process.env.KN_REDIS_URL,
-        };
-    }
+  if (process.env.KN_REDIS_URL && overridden.cache?.provider === 'redis') {
+    overridden.cache = {
+      ...overridden.cache,
+      url: process.env.KN_REDIS_URL,
+    };
+  }
 
-    return overridden;
+  return overridden;
 }
 
 async function deploy() {
-    const options = parseCliArgs();
+  const options = parseCliArgs();
 
-    log.info({ dryRun: options.dryRun }, "🚀 kn-next deploy");
+  log.info({ dryRun: options.dryRun }, '🚀 kn-next deploy');
 
-    // Load config with validation
-    const baseConfig = await loadConfig();
-    const config = applyOverrides(baseConfig, options);
+  // Load config with validation
+  const baseConfig = await loadConfig();
+  const config = applyOverrides(baseConfig, options);
 
-    const outputDir = join(process.cwd(), ".output");
+  const outputDir = join(process.cwd(), '.output');
 
-    if (!options.skipBuild) {
-        const assetPrefix = getAssetPrefix(config.storage);
-        process.env.ASSET_PREFIX = assetPrefix;
-        const preset = getNitroPreset(config);
-        log.info({ preset, assetPrefix }, "Building Vinext app with Nitro");
-        await $`NITRO_PRESET=${preset} npm run build`.quiet();
-        log.info("Vinext build complete");
+  if (!options.skipBuild) {
+    const assetPrefix = getAssetPrefix(config.storage);
+    process.env.ASSET_PREFIX = assetPrefix;
+    log.info({ assetPrefix }, 'Running next build (output:standalone)...');
+    await $`npm run build`.quiet();
+    log.info('Next.js build complete — standalone output in .next/standalone/');
+  }
+
+  const imageTag = options.tag || `${Date.now()}`;
+  const imageName = `${config.registry}/${config.name}:${imageTag}`;
+
+  log.info({ image: imageName }, 'Image tag resolved');
+
+  if (!options.dryRun) {
+    const tasks: Promise<void>[] = [];
+
+    if (!options.skipUpload) {
+      log.info('Running parallel tasks: asset upload + Docker build');
+      tasks.push(
+        (async () => {
+          await uploadAssets(config);
+          log.info('Assets uploaded');
+        })(),
+      );
     }
 
-    // Always copy adapters after build
-    await copyAdapters(outputDir);
+    log.info('Building & pushing Docker image');
+    tasks.push(
+      (async () => {
+        const repoRoot = resolve(process.cwd(), '../..');
+        await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${imageName} --push ${repoRoot}`;
+        log.info('Docker image built and pushed');
+      })(),
+    );
 
-    const imageTag = options.tag || `${Date.now()}`;
-    const imageName = `${config.registry}/${config.name}:${imageTag}`;
+    await Promise.all(tasks);
+  }
 
-    log.info({ image: imageName }, "Image tag resolved");
+  let infraEnvVars: Record<string, string> = {};
+  const hasInfra = config.infrastructure || config.observability?.enabled;
+  if (hasInfra && !options.skipInfra && !options.dryRun) {
+    log.info('Deploying infrastructure services...');
+    const { manifests, envVars } = generateInfrastructure(config, outputDir);
+    infraEnvVars = envVars;
 
-    if (!options.dryRun) {
-        const tasks: Promise<void>[] = [];
-
-        if (!options.skipUpload) {
-            log.info("Running parallel tasks: asset upload + Docker build");
-            tasks.push(
-                (async () => {
-                    await uploadAssets(config);
-                    log.info("Assets uploaded");
-                })(),
-            );
-        }
-
-        log.info("Building & pushing Docker image");
-        tasks.push(
-            (async () => {
-                const repoRoot = resolve(process.cwd(), "../..");
-                await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${imageName} --push ${repoRoot}`;
-                log.info("Docker image built and pushed");
-            })(),
-        );
-
-        await Promise.all(tasks);
+    for (const manifest of manifests) {
+      await $`kubectl apply -f ${manifest} -n ${options.namespace}`;
     }
+    log.info('Infrastructure deployed');
+  }
 
-    let infraEnvVars: Record<string, string> = {};
-    const hasInfra = config.infrastructure || config.observability?.enabled;
-    if (hasInfra && !options.skipInfra && !options.dryRun) {
-        log.info("Deploying infrastructure services...");
-        const { manifests, envVars } = generateInfrastructure(
-            config,
-            outputDir,
-        );
-        infraEnvVars = envVars;
+  if (process.env.KN_DATABASE_URL) {
+    infraEnvVars.DATABASE_URL = process.env.KN_DATABASE_URL;
+  }
 
-        for (const manifest of manifests) {
-            await $`kubectl apply -f ${manifest} -n ${options.namespace}`;
-        }
-        log.info("Infrastructure deployed");
-    }
+  log.info('Generating Knative manifest...');
+  generateKnativeManifest({
+    config,
+    outputDir,
+    imageTag,
+    namespace: options.namespace,
+    additionalEnvVars: infraEnvVars,
+  });
+  const manifestPath = join(outputDir, 'knative-service.yaml');
+  const imageCachePath = join(outputDir, 'knative-image-cache.yaml');
+  log.info({ manifest: manifestPath }, 'Manifest generated');
 
-    if (process.env.KN_DATABASE_URL) {
-        infraEnvVars.DATABASE_URL = process.env.KN_DATABASE_URL;
-    }
-
-    log.info("Generating Knative manifest...");
-    generateKnativeManifest({
-        config,
-        outputDir,
-        imageTag,
-        namespace: options.namespace,
-        additionalEnvVars: infraEnvVars,
-    });
-    const manifestPath = join(outputDir, "knative-service.yaml");
-    const imageCachePath = join(outputDir, "knative-image-cache.yaml");
-    log.info({ manifest: manifestPath }, "Manifest generated");
-
-    if (!options.dryRun) {
-        log.info("Applying to cluster...");
-        await $`kubectl apply -f ${manifestPath} -f ${imageCachePath} -n ${options.namespace}`;
-        const result =
-            await $`kubectl get ksvc ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
-        log.info({ url: result.replace(/'/g, "") }, "✨ Deployment complete!");
-    } else {
-        log.info("✅ Dry run complete - manifest generated");
-    }
+  if (!options.dryRun) {
+    log.info('Applying to cluster...');
+    await $`kubectl apply -f ${manifestPath} -f ${imageCachePath} -n ${options.namespace}`;
+    const result =
+      await $`kubectl get ksvc ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
+    log.info({ url: result.replace(/'/g, '') }, '✨ Deployment complete!');
+  } else {
+    log.info('✅ Dry run complete - manifest generated');
+  }
 }
 
 try {
-    await deploy();
+  await deploy();
 } catch (err) {
-    log.fatal({ err }, "Deployment failed");
-    process.exit(1);
+  log.fatal({ err }, 'Deployment failed');
+  process.exit(1);
 }

--- a/packages/kn-next/src/cli/deploy.ts
+++ b/packages/kn-next/src/cli/deploy.ts
@@ -10,175 +10,183 @@
  * `npm run build` script which runs `next build` with output:'standalone'.
  */
 
-import { join, resolve } from 'node:path';
-import { parseArgs } from 'node:util';
-import { $ } from 'bun';
-import type { KnativeNextConfig } from '../config';
-import { generateInfrastructure } from '../generators/infrastructure';
-import { generateKnativeManifest } from '../generators/knative-manifest';
-import { getAssetPrefix, uploadAssets } from '../utils/asset-upload';
-import { createLogger } from '../utils/logger';
-import { loadConfig } from './shared';
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { $ } from "bun";
+import type { KnativeNextConfig } from "../config";
+import { generateInfrastructure } from "../generators/infrastructure";
+import { generateKnativeManifest } from "../generators/knative-manifest";
+import { getAssetPrefix, uploadAssets } from "../utils/asset-upload";
+import { createLogger } from "../utils/logger";
+import { loadConfig } from "./shared";
 
-const log = createLogger({ module: 'deploy' });
+const log = createLogger({ module: "deploy" });
 
 interface DeployOptions {
-  registry?: string;
-  bucket?: string;
-  tag?: string;
-  namespace: string;
-  skipBuild: boolean;
-  skipUpload: boolean;
-  skipInfra: boolean;
-  dryRun: boolean;
+    registry?: string;
+    bucket?: string;
+    tag?: string;
+    namespace: string;
+    skipBuild: boolean;
+    skipUpload: boolean;
+    skipInfra: boolean;
+    dryRun: boolean;
 }
 
 function parseCliArgs(): DeployOptions {
-  const { values } = parseArgs({
-    options: {
-      registry: { type: 'string', short: 'r' },
-      bucket: { type: 'string', short: 'b' },
-      tag: { type: 'string', short: 't' },
-      namespace: { type: 'string', short: 'n', default: 'default' },
-      'skip-build': { type: 'boolean', default: false },
-      'skip-upload': { type: 'boolean', default: false },
-      'skip-infra': { type: 'boolean', default: false },
-      'dry-run': { type: 'boolean', default: false },
-      help: { type: 'boolean', short: 'h', default: false },
-    },
-    strict: true,
-    allowPositionals: true,
-  });
+    const { values } = parseArgs({
+        options: {
+            registry: { type: "string", short: "r" },
+            bucket: { type: "string", short: "b" },
+            tag: { type: "string", short: "t" },
+            namespace: { type: "string", short: "n", default: "default" },
+            "skip-build": { type: "boolean", default: false },
+            "skip-upload": { type: "boolean", default: false },
+            "skip-infra": { type: "boolean", default: false },
+            "dry-run": { type: "boolean", default: false },
+            help: { type: "boolean", short: "h", default: false },
+        },
+        strict: true,
+        allowPositionals: true,
+    });
 
-  if (values.help) {
-    log.info('Help output omitted for brevity');
-    process.exit(0);
-  }
+    if (values.help) {
+        log.info("Help output omitted for brevity");
+        process.exit(0);
+    }
 
-  return {
-    registry: values.registry || process.env.KN_REGISTRY,
-    bucket: values.bucket || process.env.KN_BUCKET,
-    tag: values.tag || process.env.KN_IMAGE_TAG,
-    namespace: values.namespace || process.env.KN_NAMESPACE || 'default',
-    skipBuild: values['skip-build'] ?? false,
-    skipUpload: values['skip-upload'] ?? false,
-    skipInfra: values['skip-infra'] ?? false,
-    dryRun: values['dry-run'] ?? false,
-  };
+    return {
+        registry: values.registry || process.env.KN_REGISTRY,
+        bucket: values.bucket || process.env.KN_BUCKET,
+        tag: values.tag || process.env.KN_IMAGE_TAG,
+        namespace: values.namespace || process.env.KN_NAMESPACE || "default",
+        skipBuild: values["skip-build"] ?? false,
+        skipUpload: values["skip-upload"] ?? false,
+        skipInfra: values["skip-infra"] ?? false,
+        dryRun: values["dry-run"] ?? false,
+    };
 }
 
-function applyOverrides(config: KnativeNextConfig, options: DeployOptions): KnativeNextConfig {
-  const overridden = { ...config };
+function applyOverrides(
+    config: KnativeNextConfig,
+    options: DeployOptions,
+): KnativeNextConfig {
+    const overridden = { ...config };
 
-  if (options.registry) {
-    overridden.registry = options.registry;
-  }
-  if (options.bucket) {
-    overridden.storage = { ...overridden.storage, bucket: options.bucket };
-  }
+    if (options.registry) {
+        overridden.registry = options.registry;
+    }
+    if (options.bucket) {
+        overridden.storage = { ...overridden.storage, bucket: options.bucket };
+    }
 
-  if (process.env.KN_REDIS_URL && overridden.cache?.provider === 'redis') {
-    overridden.cache = {
-      ...overridden.cache,
-      url: process.env.KN_REDIS_URL,
-    };
-  }
+    if (process.env.KN_REDIS_URL && overridden.cache?.provider === "redis") {
+        overridden.cache = {
+            ...overridden.cache,
+            url: process.env.KN_REDIS_URL,
+        };
+    }
 
-  return overridden;
+    return overridden;
 }
 
 async function deploy() {
-  const options = parseCliArgs();
+    const options = parseCliArgs();
 
-  log.info({ dryRun: options.dryRun }, '🚀 kn-next deploy');
+    log.info({ dryRun: options.dryRun }, "🚀 kn-next deploy");
 
-  // Load config with validation
-  const baseConfig = await loadConfig();
-  const config = applyOverrides(baseConfig, options);
+    // Load config with validation
+    const baseConfig = await loadConfig();
+    const config = applyOverrides(baseConfig, options);
 
-  const outputDir = join(process.cwd(), '.output');
+    const outputDir = join(process.cwd(), ".output");
 
-  if (!options.skipBuild) {
-    const assetPrefix = getAssetPrefix(config.storage);
-    process.env.ASSET_PREFIX = assetPrefix;
-    log.info({ assetPrefix }, 'Running next build (output:standalone)...');
-    await $`npm run build`.quiet();
-    log.info('Next.js build complete — standalone output in .next/standalone/');
-  }
-
-  const imageTag = options.tag || `${Date.now()}`;
-  const imageName = `${config.registry}/${config.name}:${imageTag}`;
-
-  log.info({ image: imageName }, 'Image tag resolved');
-
-  if (!options.dryRun) {
-    const tasks: Promise<void>[] = [];
-
-    if (!options.skipUpload) {
-      log.info('Running parallel tasks: asset upload + Docker build');
-      tasks.push(
-        (async () => {
-          await uploadAssets(config);
-          log.info('Assets uploaded');
-        })(),
-      );
+    if (!options.skipBuild) {
+        const assetPrefix = getAssetPrefix(config.storage);
+        process.env.ASSET_PREFIX = assetPrefix;
+        log.info({ assetPrefix }, "Running next build (output:standalone)...");
+        await $`npm run build`.quiet();
+        log.info(
+            "Next.js build complete — standalone output in .next/standalone/",
+        );
     }
 
-    log.info('Building & pushing Docker image');
-    tasks.push(
-      (async () => {
-        const repoRoot = resolve(process.cwd(), '../..');
-        await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${imageName} --push ${repoRoot}`;
-        log.info('Docker image built and pushed');
-      })(),
-    );
+    const imageTag = options.tag || `${Date.now()}`;
+    const imageName = `${config.registry}/${config.name}:${imageTag}`;
 
-    await Promise.all(tasks);
-  }
+    log.info({ image: imageName }, "Image tag resolved");
 
-  let infraEnvVars: Record<string, string> = {};
-  const hasInfra = config.infrastructure || config.observability?.enabled;
-  if (hasInfra && !options.skipInfra && !options.dryRun) {
-    log.info('Deploying infrastructure services...');
-    const { manifests, envVars } = generateInfrastructure(config, outputDir);
-    infraEnvVars = envVars;
+    if (!options.dryRun) {
+        const tasks: Promise<void>[] = [];
 
-    for (const manifest of manifests) {
-      await $`kubectl apply -f ${manifest} -n ${options.namespace}`;
+        if (!options.skipUpload) {
+            log.info("Running parallel tasks: asset upload + Docker build");
+            tasks.push(
+                (async () => {
+                    await uploadAssets(config);
+                    log.info("Assets uploaded");
+                })(),
+            );
+        }
+
+        log.info("Building & pushing Docker image");
+        tasks.push(
+            (async () => {
+                const repoRoot = resolve(process.cwd(), "../..");
+                await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${imageName} --push ${repoRoot}`;
+                log.info("Docker image built and pushed");
+            })(),
+        );
+
+        await Promise.all(tasks);
     }
-    log.info('Infrastructure deployed');
-  }
 
-  if (process.env.KN_DATABASE_URL) {
-    infraEnvVars.DATABASE_URL = process.env.KN_DATABASE_URL;
-  }
+    let infraEnvVars: Record<string, string> = {};
+    const hasInfra = config.infrastructure || config.observability?.enabled;
+    if (hasInfra && !options.skipInfra && !options.dryRun) {
+        log.info("Deploying infrastructure services...");
+        const { manifests, envVars } = generateInfrastructure(
+            config,
+            outputDir,
+        );
+        infraEnvVars = envVars;
 
-  log.info('Generating Knative manifest...');
-  generateKnativeManifest({
-    config,
-    outputDir,
-    imageTag,
-    namespace: options.namespace,
-    additionalEnvVars: infraEnvVars,
-  });
-  const manifestPath = join(outputDir, 'knative-service.yaml');
-  const imageCachePath = join(outputDir, 'knative-image-cache.yaml');
-  log.info({ manifest: manifestPath }, 'Manifest generated');
+        for (const manifest of manifests) {
+            await $`kubectl apply -f ${manifest} -n ${options.namespace}`;
+        }
+        log.info("Infrastructure deployed");
+    }
 
-  if (!options.dryRun) {
-    log.info('Applying to cluster...');
-    await $`kubectl apply -f ${manifestPath} -f ${imageCachePath} -n ${options.namespace}`;
-    const result =
-      await $`kubectl get ksvc ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
-    log.info({ url: result.replace(/'/g, '') }, '✨ Deployment complete!');
-  } else {
-    log.info('✅ Dry run complete - manifest generated');
-  }
+    if (process.env.KN_DATABASE_URL) {
+        infraEnvVars.DATABASE_URL = process.env.KN_DATABASE_URL;
+    }
+
+    log.info("Generating Knative manifest...");
+    generateKnativeManifest({
+        config,
+        outputDir,
+        imageTag,
+        namespace: options.namespace,
+        additionalEnvVars: infraEnvVars,
+    });
+    const manifestPath = join(outputDir, "knative-service.yaml");
+    const imageCachePath = join(outputDir, "knative-image-cache.yaml");
+    log.info({ manifest: manifestPath }, "Manifest generated");
+
+    if (!options.dryRun) {
+        log.info("Applying to cluster...");
+        await $`kubectl apply -f ${manifestPath} -f ${imageCachePath} -n ${options.namespace}`;
+        const result =
+            await $`kubectl get ksvc ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
+        log.info({ url: result.replace(/'/g, "") }, "✨ Deployment complete!");
+    } else {
+        log.info("✅ Dry run complete - manifest generated");
+    }
 }
 
 try {
-  await deploy();
+    await deploy();
 } catch (err) {
-  log.fatal({ err }, 'Deployment failed');
-  process.exit(1);
+    log.fatal({ err }, "Deployment failed");
+    process.exit(1);
 }

--- a/packages/kn-next/src/cli/shared.ts
+++ b/packages/kn-next/src/cli/shared.ts
@@ -1,72 +1,35 @@
 /**
  * Shared CLI utilities for kn-next build and deploy commands.
- * Single source of truth for config loading and adapter copying.
+ * Single source of truth for config loading.
+ *
+ * NOTE: copyAdapters and getNitroPreset were removed as part of the
+ * vinext → official Next.js Adapter migration. The CLI now runs plain
+ * `npm run build` which invokes `next build` with output:'standalone'.
+ * Adapters are no longer copied to a Nitro .output/ directory.
  */
 
-import { copyFileSync, existsSync, mkdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import type { KnativeNextConfig } from "../config";
-import { createLogger } from "../utils/logger";
-import { validateConfig } from "./validate";
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { KnativeNextConfig } from '../config';
+import { validateConfig } from './validate';
 
-const log = createLogger({ module: "cli" });
-
-const CONFIG_FILE = "kn-next.config.ts";
+const CONFIG_FILE = 'kn-next.config.ts';
 
 /**
  * Loads kn-next.config.ts from the current working directory.
  * Runs validation after loading — fails fast with clear error messages.
  */
 export async function loadConfig(): Promise<KnativeNextConfig> {
-    const configPath = resolve(process.cwd(), CONFIG_FILE);
+  const configPath = resolve(process.cwd(), CONFIG_FILE);
 
-    if (!existsSync(configPath)) {
-        throw new Error(`Config file not found: ${configPath}`);
-    }
+  if (!existsSync(configPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
 
-    const module = await import(configPath);
-    const config: KnativeNextConfig = module.default;
+  const module = await import(configPath);
+  const config: KnativeNextConfig = module.default;
 
-    validateConfig(config);
+  validateConfig(config);
 
-    return config;
-}
-
-/**
- * Copies framework adapters to the Nitro output directory.
- * Both build.ts and deploy.ts need this — single implementation here.
- */
-export async function copyAdapters(outputDir: string): Promise<void> {
-    const adaptersDir = join(outputDir, "adapters");
-    mkdirSync(adaptersDir, { recursive: true });
-
-    // Resolve adapter source relative to this file's location
-    const sourceDir = resolve(dirname(import.meta.path), "..", "adapters");
-
-    const adaptersToCopy = ["node-server.ts"];
-
-    for (const adapter of adaptersToCopy) {
-        const src = join(sourceDir, adapter);
-        const dest = join(adaptersDir, adapter);
-        if (existsSync(src)) {
-            copyFileSync(src, dest);
-            log.info({ adapter }, "Copied adapter");
-        }
-    }
-
-    // Copy custom cache handler if it exists in the app directory
-    const cacheHandlerSrc = join(process.cwd(), "cache-handler.js");
-    if (existsSync(cacheHandlerSrc)) {
-        copyFileSync(cacheHandlerSrc, join(adaptersDir, "cache-handler.js"));
-        log.info("Copied cache-handler.js");
-    }
-}
-
-/**
- * Returns the Nitro preset based on config.runtime.
- * Default: 'bun' (matches Dockerfile and deploy pipeline).
- */
-export function getNitroPreset(config: KnativeNextConfig): string {
-    const runtime = config.runtime ?? "bun";
-    return runtime === "bun" ? "bun" : "node-server";
+  return config;
 }

--- a/packages/kn-next/src/cli/shared.ts
+++ b/packages/kn-next/src/cli/shared.ts
@@ -8,28 +8,28 @@
  * Adapters are no longer copied to a Nitro .output/ directory.
  */
 
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
-import type { KnativeNextConfig } from '../config';
-import { validateConfig } from './validate';
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { KnativeNextConfig } from "../config";
+import { validateConfig } from "./validate";
 
-const CONFIG_FILE = 'kn-next.config.ts';
+const CONFIG_FILE = "kn-next.config.ts";
 
 /**
  * Loads kn-next.config.ts from the current working directory.
  * Runs validation after loading — fails fast with clear error messages.
  */
 export async function loadConfig(): Promise<KnativeNextConfig> {
-  const configPath = resolve(process.cwd(), CONFIG_FILE);
+    const configPath = resolve(process.cwd(), CONFIG_FILE);
 
-  if (!existsSync(configPath)) {
-    throw new Error(`Config file not found: ${configPath}`);
-  }
+    if (!existsSync(configPath)) {
+        throw new Error(`Config file not found: ${configPath}`);
+    }
 
-  const module = await import(configPath);
-  const config: KnativeNextConfig = module.default;
+    const module = await import(configPath);
+    const config: KnativeNextConfig = module.default;
 
-  validateConfig(config);
+    validateConfig(config);
 
-  return config;
+    return config;
 }

--- a/packages/kn-next/src/config.ts
+++ b/packages/kn-next/src/config.ts
@@ -1,120 +1,120 @@
 // Storage providers
-export type StorageProvider = 's3' | 'gcs' | 'azure' | 'minio';
+export type StorageProvider = "s3" | "gcs" | "azure" | "minio";
 
 export interface StorageConfig {
-  provider: StorageProvider;
-  bucket: string;
-  region?: string;
-  endpoint?: string; // For MinIO/S3-compatible
-  publicUrl: string; // Public CDN URL where assets are served from (e.g. https://storage.googleapis.com/my-bucket)
-  accessKey?: string; // Optional, use IAM when possible
-  secretKey?: string;
+    provider: StorageProvider;
+    bucket: string;
+    region?: string;
+    endpoint?: string; // For MinIO/S3-compatible
+    publicUrl: string; // Public CDN URL where assets are served from (e.g. https://storage.googleapis.com/my-bucket)
+    accessKey?: string; // Optional, use IAM when possible
+    secretKey?: string;
 }
 
 // Cache adapters
-export type CacheProvider = 'redis' | 'dynamodb';
+export type CacheProvider = "redis" | "dynamodb";
 
 export interface RedisCacheConfig {
-  provider: 'redis';
-  url: string;
-  keyPrefix?: string;
-  tls?: boolean;
+    provider: "redis";
+    url: string;
+    keyPrefix?: string;
+    tls?: boolean;
 }
 
 export interface DynamoDBCacheConfig {
-  provider: 'dynamodb';
-  tableName: string;
-  region: string;
-  accessKey?: string;
-  secretKey?: string;
+    provider: "dynamodb";
+    tableName: string;
+    region: string;
+    accessKey?: string;
+    secretKey?: string;
 }
 
 export type CacheConfig = RedisCacheConfig | DynamoDBCacheConfig;
 
 // Queue providers for ISR revalidation
-export type QueueProvider = 'kafka' | 'none';
+export type QueueProvider = "kafka" | "none";
 
 export interface KafkaQueueConfig {
-  provider: 'kafka';
-  brokerUrl: string;
-  topic?: string; // Defaults to '{name}-isr-revalidation'
-  clientId?: string;
+    provider: "kafka";
+    brokerUrl: string;
+    topic?: string; // Defaults to '{name}-isr-revalidation'
+    clientId?: string;
 }
 
 export interface NoQueueConfig {
-  provider: 'none';
+    provider: "none";
 }
 
 export type QueueConfig = KafkaQueueConfig | NoQueueConfig;
 
 // Infrastructure services (deployed as Knative services)
 export interface PostgresConfig {
-  enabled: boolean;
-  version?: string; // Default: "16"
-  storage?: string; // Default: "1Gi"
+    enabled: boolean;
+    version?: string; // Default: "16"
+    storage?: string; // Default: "1Gi"
 }
 
 export interface RedisInfraConfig {
-  enabled: boolean;
-  version?: string; // Default: "7"
+    enabled: boolean;
+    version?: string; // Default: "7"
 }
 
 export interface MinioInfraConfig {
-  enabled: boolean;
-  storage?: string; // Default: "10Gi"
-  accessKey?: string; // Default: "minioadmin"
-  secretKey?: string; // Default: "minioadmin"
+    enabled: boolean;
+    storage?: string; // Default: "10Gi"
+    accessKey?: string; // Default: "minioadmin"
+    secretKey?: string; // Default: "minioadmin"
 }
 
 export interface InfrastructureConfig {
-  postgres?: PostgresConfig;
-  redis?: RedisInfraConfig;
-  minio?: MinioInfraConfig;
+    postgres?: PostgresConfig;
+    redis?: RedisInfraConfig;
+    minio?: MinioInfraConfig;
 }
 
 // Knative autoscaling configuration
 export interface ScalingConfig {
-  minScale?: number; // Default: 0 (scale to zero)
-  maxScale?: number; // Default: 10
-  cpuRequest?: string; // Default: "250m"
-  memoryRequest?: string; // Default: "512Mi"
-  cpuLimit?: string; // Default: "1000m"
-  memoryLimit?: string; // Default: "1Gi"
+    minScale?: number; // Default: 0 (scale to zero)
+    maxScale?: number; // Default: 10
+    cpuRequest?: string; // Default: "250m"
+    memoryRequest?: string; // Default: "512Mi"
+    cpuLimit?: string; // Default: "1000m"
+    memoryLimit?: string; // Default: "1Gi"
 }
 
 // Observability — Prometheus metrics + Grafana dashboards
 export interface ObservabilityConfig {
-  enabled: boolean;
-  prometheus?: {
-    scrapeInterval?: string; // Default: "15s"
-  };
-  grafana?: {
-    enabled?: boolean; // Default: true (deploy dashboard ConfigMap)
-  };
+    enabled: boolean;
+    prometheus?: {
+        scrapeInterval?: string; // Default: "15s"
+    };
+    grafana?: {
+        enabled?: boolean; // Default: true (deploy dashboard ConfigMap)
+    };
 }
 
 // Kubernetes Native Secrets Binding
 export interface SecretRef {
-  name: string; // Name of the Kubernetes Secret resource
-  key?: string; // Specific key within the Secret (if mapping a single env var)
+    name: string; // Name of the Kubernetes Secret resource
+    key?: string; // Specific key within the Secret (if mapping a single env var)
 }
 
 export interface SecretsConfig {
-  envFrom?: string[]; // Array of Secret names to inject fully as environment variables
-  envMap?: Record<string, SecretRef>; // Map of explicit ENV_VAR -> { name, key } Secret mapping
+    envFrom?: string[]; // Array of Secret names to inject fully as environment variables
+    envMap?: Record<string, SecretRef>; // Map of explicit ENV_VAR -> { name, key } Secret mapping
 }
 
 // Main Knative-Next config (subset of OpenNext we support)
 export interface KnativeNextConfig {
-  name: string;
-  storage: StorageConfig;
-  cache?: CacheConfig;
-  queue?: QueueConfig; // For ISR revalidation (Kafka for Knative Eventing)
-  registry: string;
-  runtime?: 'bun' | 'node'; // Runtime to execute the Next.js standalone server.js: 'bun' or 'node' (default)
-  infrastructure?: InfrastructureConfig; // Deploy PostgreSQL, Redis, MinIO as Knative services
-  scaling?: ScalingConfig; // Knative autoscaling options
-  observability?: ObservabilityConfig; // Prometheus metrics + Grafana dashboards
-  healthCheckPath?: string; // Default: "/api/health"
-  secrets?: SecretsConfig; // Kubernetes Native Secrets Binding
+    name: string;
+    storage: StorageConfig;
+    cache?: CacheConfig;
+    queue?: QueueConfig; // For ISR revalidation (Kafka for Knative Eventing)
+    registry: string;
+    runtime?: "bun" | "node"; // Runtime to execute the Next.js standalone server.js: 'bun' or 'node' (default)
+    infrastructure?: InfrastructureConfig; // Deploy PostgreSQL, Redis, MinIO as Knative services
+    scaling?: ScalingConfig; // Knative autoscaling options
+    observability?: ObservabilityConfig; // Prometheus metrics + Grafana dashboards
+    healthCheckPath?: string; // Default: "/api/health"
+    secrets?: SecretsConfig; // Kubernetes Native Secrets Binding
 }

--- a/packages/kn-next/src/config.ts
+++ b/packages/kn-next/src/config.ts
@@ -1,120 +1,120 @@
 // Storage providers
-export type StorageProvider = "s3" | "gcs" | "azure" | "minio";
+export type StorageProvider = 's3' | 'gcs' | 'azure' | 'minio';
 
 export interface StorageConfig {
-    provider: StorageProvider;
-    bucket: string;
-    region?: string;
-    endpoint?: string; // For MinIO/S3-compatible
-    publicUrl: string; // Public CDN URL where assets are served from (e.g. https://storage.googleapis.com/my-bucket)
-    accessKey?: string; // Optional, use IAM when possible
-    secretKey?: string;
+  provider: StorageProvider;
+  bucket: string;
+  region?: string;
+  endpoint?: string; // For MinIO/S3-compatible
+  publicUrl: string; // Public CDN URL where assets are served from (e.g. https://storage.googleapis.com/my-bucket)
+  accessKey?: string; // Optional, use IAM when possible
+  secretKey?: string;
 }
 
 // Cache adapters
-export type CacheProvider = "redis" | "dynamodb";
+export type CacheProvider = 'redis' | 'dynamodb';
 
 export interface RedisCacheConfig {
-    provider: "redis";
-    url: string;
-    keyPrefix?: string;
-    tls?: boolean;
+  provider: 'redis';
+  url: string;
+  keyPrefix?: string;
+  tls?: boolean;
 }
 
 export interface DynamoDBCacheConfig {
-    provider: "dynamodb";
-    tableName: string;
-    region: string;
-    accessKey?: string;
-    secretKey?: string;
+  provider: 'dynamodb';
+  tableName: string;
+  region: string;
+  accessKey?: string;
+  secretKey?: string;
 }
 
 export type CacheConfig = RedisCacheConfig | DynamoDBCacheConfig;
 
 // Queue providers for ISR revalidation
-export type QueueProvider = "kafka" | "none";
+export type QueueProvider = 'kafka' | 'none';
 
 export interface KafkaQueueConfig {
-    provider: "kafka";
-    brokerUrl: string;
-    topic?: string; // Defaults to '{name}-isr-revalidation'
-    clientId?: string;
+  provider: 'kafka';
+  brokerUrl: string;
+  topic?: string; // Defaults to '{name}-isr-revalidation'
+  clientId?: string;
 }
 
 export interface NoQueueConfig {
-    provider: "none";
+  provider: 'none';
 }
 
 export type QueueConfig = KafkaQueueConfig | NoQueueConfig;
 
 // Infrastructure services (deployed as Knative services)
 export interface PostgresConfig {
-    enabled: boolean;
-    version?: string; // Default: "16"
-    storage?: string; // Default: "1Gi"
+  enabled: boolean;
+  version?: string; // Default: "16"
+  storage?: string; // Default: "1Gi"
 }
 
 export interface RedisInfraConfig {
-    enabled: boolean;
-    version?: string; // Default: "7"
+  enabled: boolean;
+  version?: string; // Default: "7"
 }
 
 export interface MinioInfraConfig {
-    enabled: boolean;
-    storage?: string; // Default: "10Gi"
-    accessKey?: string; // Default: "minioadmin"
-    secretKey?: string; // Default: "minioadmin"
+  enabled: boolean;
+  storage?: string; // Default: "10Gi"
+  accessKey?: string; // Default: "minioadmin"
+  secretKey?: string; // Default: "minioadmin"
 }
 
 export interface InfrastructureConfig {
-    postgres?: PostgresConfig;
-    redis?: RedisInfraConfig;
-    minio?: MinioInfraConfig;
+  postgres?: PostgresConfig;
+  redis?: RedisInfraConfig;
+  minio?: MinioInfraConfig;
 }
 
 // Knative autoscaling configuration
 export interface ScalingConfig {
-    minScale?: number; // Default: 0 (scale to zero)
-    maxScale?: number; // Default: 10
-    cpuRequest?: string; // Default: "250m"
-    memoryRequest?: string; // Default: "512Mi"
-    cpuLimit?: string; // Default: "1000m"
-    memoryLimit?: string; // Default: "1Gi"
+  minScale?: number; // Default: 0 (scale to zero)
+  maxScale?: number; // Default: 10
+  cpuRequest?: string; // Default: "250m"
+  memoryRequest?: string; // Default: "512Mi"
+  cpuLimit?: string; // Default: "1000m"
+  memoryLimit?: string; // Default: "1Gi"
 }
 
 // Observability — Prometheus metrics + Grafana dashboards
 export interface ObservabilityConfig {
-    enabled: boolean;
-    prometheus?: {
-        scrapeInterval?: string; // Default: "15s"
-    };
-    grafana?: {
-        enabled?: boolean; // Default: true (deploy dashboard ConfigMap)
-    };
+  enabled: boolean;
+  prometheus?: {
+    scrapeInterval?: string; // Default: "15s"
+  };
+  grafana?: {
+    enabled?: boolean; // Default: true (deploy dashboard ConfigMap)
+  };
 }
 
 // Kubernetes Native Secrets Binding
 export interface SecretRef {
-    name: string; // Name of the Kubernetes Secret resource
-    key?: string; // Specific key within the Secret (if mapping a single env var)
+  name: string; // Name of the Kubernetes Secret resource
+  key?: string; // Specific key within the Secret (if mapping a single env var)
 }
 
 export interface SecretsConfig {
-    envFrom?: string[]; // Array of Secret names to inject fully as environment variables
-    envMap?: Record<string, SecretRef>; // Map of explicit ENV_VAR -> { name, key } Secret mapping
+  envFrom?: string[]; // Array of Secret names to inject fully as environment variables
+  envMap?: Record<string, SecretRef>; // Map of explicit ENV_VAR -> { name, key } Secret mapping
 }
 
 // Main Knative-Next config (subset of OpenNext we support)
 export interface KnativeNextConfig {
-    name: string;
-    storage: StorageConfig;
-    cache?: CacheConfig;
-    queue?: QueueConfig; // For ISR revalidation (Kafka for Knative Eventing)
-    registry: string;
-    runtime?: "bun" | "node"; // Nitro preset: 'bun' (default) or 'node' (node-server)
-    infrastructure?: InfrastructureConfig; // Deploy PostgreSQL, Redis, MinIO as Knative services
-    scaling?: ScalingConfig; // Knative autoscaling options
-    observability?: ObservabilityConfig; // Prometheus metrics + Grafana dashboards
-    healthCheckPath?: string; // Default: "/api/health"
-    secrets?: SecretsConfig; // Kubernetes Native Secrets Binding
+  name: string;
+  storage: StorageConfig;
+  cache?: CacheConfig;
+  queue?: QueueConfig; // For ISR revalidation (Kafka for Knative Eventing)
+  registry: string;
+  runtime?: 'bun' | 'node'; // Runtime to execute the Next.js standalone server.js: 'bun' or 'node' (default)
+  infrastructure?: InfrastructureConfig; // Deploy PostgreSQL, Redis, MinIO as Knative services
+  scaling?: ScalingConfig; // Knative autoscaling options
+  observability?: ObservabilityConfig; // Prometheus metrics + Grafana dashboards
+  healthCheckPath?: string; // Default: "/api/health"
+  secrets?: SecretsConfig; // Kubernetes Native Secrets Binding
 }


### PR DESCRIPTION
## Complete the vinext → official Next.js Adapter migration (Node + bytecode caching)

Finishes removing Vinext/Nitro from the **framework** (not just the app) so knext runs on the
**official Next.js Deployment Adapter API + `output:'standalone'`**, on **Node.js with
`NODE_COMPILE_CACHE`** bytecode caching. Built TDD (RED→GREEN) by the superteam; spec-review and
code-review both **APPROVED**.

### Code
- `packages/kn-next/src/cli/{build,deploy,shared}.ts` — removed Nitro build orchestration
  (`NITRO_PRESET`, `getNitroPreset`, Nitro `copyAdapters`); build drives `next build` standalone.
- `packages/kn-next/src/adapters/node-server.ts` — dropped the Nitro `.output/server/index.mjs`
  coupling; spawns the standalone `server.js`.
- `packages/kn-next/src/adapters/env.ts` *(new)* — pure `buildChildEnv()` that spreads
  `process.env` first, so an operator-supplied `NODE_COMPILE_CACHE` (PVC path) is **forwarded and
  not clobbered**.
- `packages/kn-next/src/config.ts` — removed Nitro "preset" runtime semantics.
- `apps/file-manager/Dockerfile` — Node standalone; `CMD` uses
  `${NODE_COMPILE_CACHE:=<fallback>}` so the operator's value wins, with an in-image fallback.

### Bytecode caching (the goal)
- `NODE_COMPILE_CACHE` is forwarded by `buildChildEnv()`, defaulted (not overridden) by the
  Dockerfile, and injected by the operator (`nextapp_controller.go:201`).
- 3 RED-first tests in `packages/kn-next/src/__tests__/adapter-migration.test.ts`: forwarded when
  set, operator PVC path not clobbered, absent when unset.

### Docs
- `docs/ARCHITECTURE.md` — vinext → official adapter; ISR/data cache correctly labelled **Redis**
  (table + mermaid + prose now consistent), GCS = static assets only.
- `docs/VINEXT_MIGRATION_PLAN.md` retired (historical banner); operator docs + bun-bytecode spike swept.

### Verification
- `packages/kn-next` (the migrated framework): **17/17 tests pass**, `tsc` clean, `biome` 0 errors.
- TDD verified in history: RED `4fc1032`→GREEN `bf3d956`; RED `3642a2c`→GREEN `0615569`.
- `grep -riE 'vinext|nitro' packages/kn-next/src` → no active build/runtime path.

### Known follow-ups (pre-existing, not introduced here)
- `apps/file-manager/vite.config.ts` + `server.ts` still carry dead vinext/nitro imports (demo-app
  cleanup — recommend a follow-up ticket).
- `apps/spike-bun-bytecode` build + an untracked `packages/knext/` test fail on `main` already
  (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
