### PR TITLE
docs: A3-3 — correct stale 'node-server.ts welded to Nitro' claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@
 - **Do NOT reverse-engineer Nitro/Vinext** (old epic #11 approach is superseded).
 - **Don't rewrite the runtime twice** — land the adapter migration before other runtime changes.
 - **Status:** the official-adapter + `output:'standalone'` migration **merged to `main` (PR #29)**;
-  cold-start bytecode caching via `NODE_COMPILE_CACHE`. The deprecated Vinext/Nitro runtime
-  (`node-server.ts`) is on its way out.
+  cold-start bytecode caching via `NODE_COMPILE_CACHE`. The Vinext/Nitro runtime coupling is
+  **gone from the tracked codebase** — `node-server.ts` is now the standalone-server runtime entry
+  (spawns `next build`'s `server.js` + a metrics sidecar), not a Nitro entry.
 
 ## 4. Control plane (ADR-0001)
 - The **Go operator is the single source of truth** for cluster state. The TS CLI must stop
@@ -85,8 +86,11 @@ defer bucket 1.
 - Real data plane = **GCS + Redis on GKE**; S3/Azure/MinIO are thin shell-outs; DynamoDB/Kafka are
   config/manifest-only — implement+test or trim the schema/docs.
 - **Image optimization missing** (biggest functional gap).
-- `packages/kn-next/src/adapters/node-server.ts` **still welded to Nitro** (`.output/server/index.mjs`,
-  lines ~13/30) — **not yet removed** on `main`; retire it to finish the migration.
+- **(RESOLVED 2026-06-20)** `packages/kn-next/src/adapters/node-server.ts` is **Nitro-free** — it
+  spawns the standalone `server.js` (`STANDALONE_SERVER_PATH`, default `.next/standalone/server.js`),
+  no `.output/server`/`index.mjs`. Enforced by `adapter-migration.test.ts` (asserts no `.output/server`).
+  The only remaining `nitro/runtime` references are **untracked local cruft** (`packages/admin/…`,
+  a stray `apps/file-manager/src/server/plugins/knext.ts`) — not in git, nothing to delete from the repo.
 - Tests light on core build/deploy/upload/cache paths (manifest gen is covered).
 - Operator gaps: status `Conditions` field **defined** (`nextapp_types.go:144`) but **not populated**
   by the reconciler (only `status.url` is set); no finalizer logic; happy-path reconcile;


### PR DESCRIPTION
## Summary

**A3-3 turned out to be already done in code** — this PR corrects the record.

The canonical `CLAUDE.md` §9 claimed `node-server.ts` was *still welded to Nitro* (`.output/server/index.mjs`) and *not yet removed*. Verified against source, that is false:

- `node-server.ts` spawns the standalone `server.js` (`STANDALONE_SERVER_PATH`, default `.next/standalone/server.js`) + a metrics sidecar — **zero** `.output/server` / `nitro/runtime`.
- `adapter-migration.test.ts` already asserts it contains no `.output/server` (green).
- The only remaining `nitro/runtime` references are **untracked local cruft** (`packages/admin/...` has 0 git-tracked files; a stray `apps/file-manager/src/server/plugins/knext.ts`) — not in the repo, nothing to delete.

So the A3-3 exit criteria (\"no `.output/server` references; adapter is sole runtime\") are met in the tracked tree. This corrects the stale strategy note so future work is not misdirected.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)