### PR TITLE
arch: surface REDIS_KEY_PREFIX drift + dedup config loading

### DIFF
--- a/packages/kn-next/src/__tests__/cache-handler-keyprefix.test.ts
+++ b/packages/kn-next/src/__tests__/cache-handler-keyprefix.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Guards the REDIS_KEY_PREFIX drift surfaced by the architecture review (#2):
+ * the manifest generator sets REDIS_KEY_PREFIX to the app name, but the
+ * cache-handler falls back to 'kn-next' when the var is unset. If that fallback
+ * happens silently while Redis is in use, ISR keys land in a different keyspace
+ * than the rest of the app's pods. The cache-handler now warns loudly instead.
+ *
+ * cache-handler.js reads env at module load, so each case resets the module
+ * registry and re-imports with a fresh environment.
+ */
+describe("cache-handler REDIS_KEY_PREFIX guard", () => {
+    const original = { ...process.env };
+
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        process.env = { ...original };
+        vi.restoreAllMocks();
+    });
+
+    const matcher = expect.stringContaining("REDIS_KEY_PREFIX is unset");
+    // Non-literal specifier: cache-handler.js is a plain-JS runtime shim with no
+    // type declarations; a variable import avoids tsc's implicit-any on the module.
+    const CACHE_HANDLER: string = "../adapters/cache-handler.js";
+
+    it("warns when REDIS_URL is set but REDIS_KEY_PREFIX is not", async () => {
+        process.env.REDIS_URL = "redis://localhost:6379";
+        delete process.env.REDIS_KEY_PREFIX;
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await import(CACHE_HANDLER);
+
+        expect(warn).toHaveBeenCalledWith(matcher);
+    });
+
+    it("does not warn when REDIS_KEY_PREFIX is set", async () => {
+        process.env.REDIS_URL = "redis://localhost:6379";
+        process.env.REDIS_KEY_PREFIX = "my-app";
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await import(CACHE_HANDLER);
+
+        expect(warn).not.toHaveBeenCalledWith(matcher);
+    });
+
+    it("does not warn in in-memory mode (no REDIS_URL)", async () => {
+        delete process.env.REDIS_URL;
+        delete process.env.REDIS_KEY_PREFIX;
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await import(CACHE_HANDLER);
+
+        expect(warn).not.toHaveBeenCalledWith(matcher);
+    });
+});

--- a/packages/kn-next/src/adapters/cache-handler.js
+++ b/packages/kn-next/src/adapters/cache-handler.js
@@ -64,6 +64,18 @@ function logCacheEvent(type, source, key, options) {
 // ─── Redis Client (lazy, only when REDIS_URL is set) ───
 
 const REDIS_URL = process.env.REDIS_URL;
+// REDIS_KEY_PREFIX is set by the deploy path (manifest generator / operator) to the
+// app name, so each app owns an isolated ISR keyspace. If Redis is in use but the var
+// is unset, the fallback below ('kn-next') will NOT match the app-name keyspace other
+// pods read/write — a silent split keyspace = cache misses + cross-app collisions.
+// Surface it loudly rather than diverging quietly (see architecture review #2).
+if (REDIS_URL && !process.env.REDIS_KEY_PREFIX) {
+  console.warn(
+    "[cache-handler] REDIS_KEY_PREFIX is unset while REDIS_URL is set — falling back " +
+      "to 'kn-next'. ISR cache keys may not match the deploy-time prefix (app name); " +
+      'set REDIS_KEY_PREFIX to avoid a split keyspace.',
+  );
+}
 const KEY_PREFIX = process.env.REDIS_KEY_PREFIX || 'kn-next';
 
 let Redis;

--- a/packages/kn-next/src/cli/cleanup.ts
+++ b/packages/kn-next/src/cli/cleanup.ts
@@ -11,26 +11,14 @@
  *   3. Clear storage bucket
  */
 
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
 import { $ } from "bun";
 import type { KnativeNextConfig } from "../config";
 import { createLogger } from "../utils/logger";
+// Single source of truth for config loading — also runs validateConfig,
+// which cleanup's former private copy skipped (CONFIG-LOAD-DEDUP).
+import { loadConfig } from "./shared";
 
 const log = createLogger({ module: "cleanup" });
-
-const CONFIG_FILE = "kn-next.config.ts";
-
-async function loadConfig(): Promise<KnativeNextConfig> {
-    const configPath = resolve(process.cwd(), CONFIG_FILE);
-
-    if (!existsSync(configPath)) {
-        throw new Error(`Config file not found: ${configPath}`);
-    }
-
-    const module = await import(configPath);
-    return module.default;
-}
 
 async function cleanup() {
     log.info("🧹 kn-next cleanup");


### PR DESCRIPTION
First two improvements from the architecture review (the deep-module pass), starting with the **verified-safe** ones.

## #2 — REDIS_KEY_PREFIX silent drift (real bug)
The manifest generator sets \`REDIS_KEY_PREFIX\` to the **app name** so each app owns an isolated ISR keyspace (\`knative-manifest.ts:40\`). But \`cache-handler.js\` falls back to \`'kn-next'\` when the var is unset (\`:67\`) — a **silent split keyspace** (cache misses + cross-app collisions) if the deploy path ever omits it.

→ cache-handler now **warns loudly** when \`REDIS_URL\` is set but \`REDIS_KEY_PREFIX\` is not, instead of diverging quietly. Covered by a 3-case test (warns / does-not-warn-when-set / does-not-warn-in-memory).

## #5 — config-loading duplication
\`cleanup.ts\` carried its own \`loadConfig\` copy that **skipped \`validateConfig\`**. It now reuses \`cli/shared.ts\` (the single source of truth) — removes the copy **and** adds the validation cleanup lacked.

## What I did NOT do (verification caught the report over-reaching)
The review also flagged \`loader.ts\`, the \`build.ts\` manifest path, and \`infrastructure.ts\` as deletable. Ground-truthing against source: \`loader.ts\` is a **published export** with a consumer (\`scripts/print-config.ts\`) **and a test**; \`build.ts:69\` **actively calls** the generator; infrastructure deferral is plausibly intentional (ADR-0001). **None deleted.**

## Verify
- \`tsc --noEmit\` clean · **76/76** kn-next tests · Biome clean

The larger candidates (#1 collapse the dual spec→ksvc translation, #2 full runtime-env seam, #4 deploy plan) are refactors for the grilling design loop, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)