### PR TITLE
build: run the kn-next CLI on plain Node — unblock npx kn-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "happy-dom": "^20.0.11",
     "jsdom": "^27.3.0",
     "minio": "^8.0.6",
+    "tsup": "^8.5.1",
     "turbo": "latest",
     "vitest": "^4.0.16"
   },

--- a/packages/kn-next/package.json
+++ b/packages/kn-next/package.json
@@ -6,7 +6,7 @@
   "main": "./src/config.ts",
   "types": "./src/config.ts",
   "bin": {
-    "kn-next": "./src/cli/deploy.ts"
+    "kn-next": "./dist/cli/kn-next.js"
   },
   "exports": {
     ".": "./src/config.ts",
@@ -18,8 +18,8 @@
     "./cli/shared": "./src/cli/shared.ts"
   },
   "scripts": {
-    "build": "tsc --noEmit",
-    "deploy": "bun run ./src/cli/deploy.ts",
+    "build": "tsup",
+    "deploy": "node ./dist/cli/kn-next.js",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "typecheck": "tsc --noEmit",
@@ -28,7 +28,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "files": [
-    "src"
+    "src",
+    "dist"
   ],
   "keywords": [
     "knative",

--- a/packages/kn-next/src/cli/build.ts
+++ b/packages/kn-next/src/cli/build.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
+
 /**
  * kn-next build — Prepares Next.js app for Knative deployment.
  *
@@ -19,9 +20,9 @@
  * reconciles everything from the NextApp CR emitted by `deploy`.
  */
 
-import { $ } from "bun";
 import { uploadAssets } from "../utils/asset-upload";
 import { createLogger } from "../utils/logger";
+import { isEntrypoint, runQuiet } from "./exec";
 import { loadConfig } from "./shared";
 
 const log = createLogger({ module: "build" });
@@ -50,7 +51,7 @@ export async function build(options: BuildOptions = {}) {
     //    The app's next.config.ts must set output:'standalone'.
     if (!options.skipNextBuild) {
         log.info("Running next build (output:standalone)...");
-        await $`npm run build`.quiet();
+        runQuiet(["npm", "run", "build"]);
         log.info(
             "Next.js build complete — standalone output in .next/standalone/",
         );
@@ -66,8 +67,9 @@ export async function build(options: BuildOptions = {}) {
     );
 }
 
-// Run if executed directly
-if (import.meta.main) {
+// Run only when invoked directly as the entry (not when imported, e.g. in tests).
+// Node-correct replacement for Bun's `import.meta.main`.
+if (isEntrypoint(import.meta.url)) {
     try {
         await build({
             skipNextBuild: process.argv.includes("--skip-next"),

--- a/packages/kn-next/src/cli/cleanup.ts
+++ b/packages/kn-next/src/cli/cleanup.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
+
 /**
  * kn-next cleanup - Removes Knative services and clears storage
  *
@@ -11,9 +12,9 @@
  *   3. Clear storage bucket
  */
 
-import { $ } from "bun";
 import type { KnativeNextConfig } from "../config";
 import { createLogger } from "../utils/logger";
+import { isEntrypoint, runQuiet, runQuietAllowFail } from "./exec";
 // Single source of truth for config loading — also runs validateConfig,
 // which cleanup's former private copy skipped (CONFIG-LOAD-DEDUP).
 import { loadConfig } from "./shared";
@@ -37,7 +38,13 @@ async function cleanup() {
     // 2. Delete Knative service
     log.info("Deleting Knative service...");
     try {
-        await $`kubectl delete ksvc ${config.name} --ignore-not-found`.quiet();
+        runQuiet([
+            "kubectl",
+            "delete",
+            "ksvc",
+            config.name,
+            "--ignore-not-found",
+        ]);
         log.info({ service: config.name }, "Deleted Knative service");
     } catch (_err) {
         log.warn("Service not found or already deleted");
@@ -47,20 +54,55 @@ async function cleanup() {
     if (config.infrastructure) {
         log.info("Deleting infrastructure services...");
         if (config.infrastructure.postgres?.enabled) {
-            await $`kubectl delete statefulset ${config.name}-postgres --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-postgres --ignore-not-found`.quiet();
-            await $`kubectl delete pvc -l app=${config.name}-postgres --ignore-not-found`.quiet();
+            const pg = `${config.name}-postgres`;
+            runQuiet([
+                "kubectl",
+                "delete",
+                "statefulset",
+                pg,
+                "--ignore-not-found",
+            ]);
+            runQuiet(["kubectl", "delete", "svc", pg, "--ignore-not-found"]);
+            runQuiet([
+                "kubectl",
+                "delete",
+                "pvc",
+                "-l",
+                `app=${pg}`,
+                "--ignore-not-found",
+            ]);
             log.info("Deleted PostgreSQL");
         }
         if (config.infrastructure.redis?.enabled) {
-            await $`kubectl delete deployment ${config.name}-redis --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-redis --ignore-not-found`.quiet();
+            const redis = `${config.name}-redis`;
+            runQuiet([
+                "kubectl",
+                "delete",
+                "deployment",
+                redis,
+                "--ignore-not-found",
+            ]);
+            runQuiet(["kubectl", "delete", "svc", redis, "--ignore-not-found"]);
             log.info("Deleted Redis");
         }
         if (config.infrastructure.minio?.enabled) {
-            await $`kubectl delete statefulset ${config.name}-minio --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-minio --ignore-not-found`.quiet();
-            await $`kubectl delete pvc -l app=${config.name}-minio --ignore-not-found`.quiet();
+            const minio = `${config.name}-minio`;
+            runQuiet([
+                "kubectl",
+                "delete",
+                "statefulset",
+                minio,
+                "--ignore-not-found",
+            ]);
+            runQuiet(["kubectl", "delete", "svc", minio, "--ignore-not-found"]);
+            runQuiet([
+                "kubectl",
+                "delete",
+                "pvc",
+                "-l",
+                `app=${minio}`,
+                "--ignore-not-found",
+            ]);
             log.info("Deleted MinIO");
         }
     }
@@ -76,24 +118,53 @@ async function cleanup() {
 async function clearStorage(config: KnativeNextConfig) {
     switch (config.storage.provider) {
         case "gcs":
-            await $`gsutil -m rm -r gs://${config.storage.bucket}/** 2>/dev/null || true`.quiet();
+            // gsutil expands the `**` wildcard itself (single argv token).
+            // Tolerate a non-zero exit (empty bucket) — the old `|| true` idiom.
+            runQuietAllowFail([
+                "gsutil",
+                "-m",
+                "rm",
+                "-r",
+                `gs://${config.storage.bucket}/**`,
+            ]);
             break;
         case "s3":
-            await $`aws s3 rm s3://${config.storage.bucket} --recursive`.quiet();
+            runQuiet([
+                "aws",
+                "s3",
+                "rm",
+                `s3://${config.storage.bucket}`,
+                "--recursive",
+            ]);
             break;
         case "minio":
-            await $`mc rm --recursive --force minio/${config.storage.bucket}`.quiet();
+            runQuiet([
+                "mc",
+                "rm",
+                "--recursive",
+                "--force",
+                `minio/${config.storage.bucket}`,
+            ]);
             break;
         case "azure":
-            await $`az storage blob delete-batch -s ${config.storage.bucket}`.quiet();
+            runQuiet([
+                "az",
+                "storage",
+                "blob",
+                "delete-batch",
+                "-s",
+                config.storage.bucket,
+            ]);
             break;
     }
 }
 
-// Run
-try {
-    await cleanup();
-} catch (err) {
-    log.fatal({ err }, "Cleanup failed");
-    process.exit(1);
+// Run only when invoked directly as the entry (not when imported, e.g. in tests).
+if (isEntrypoint(import.meta.url)) {
+    try {
+        await cleanup();
+    } catch (err) {
+        log.fatal({ err }, "Cleanup failed");
+        process.exit(1);
+    }
 }

--- a/packages/kn-next/src/cli/deploy.ts
+++ b/packages/kn-next/src/cli/deploy.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 /**
  * kn-next CLI — Knative Next.js Deployment Automation
  *
@@ -16,9 +16,10 @@
  * The operator reconciles everything from the NextApp CR.
  */
 
+import { readFileSync, writeSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
-import { $ } from "bun";
 import type { KnativeNextConfig } from "../config";
 import { getAssetPrefix, uploadAssets } from "../utils/asset-upload";
 import { createLogger } from "../utils/logger";
@@ -27,6 +28,7 @@ import {
     resolveDigest,
     validateCRImageRef,
 } from "./cr-builder";
+import { isEntrypoint, runCapture, runInherit, runQuiet } from "./exec";
 import { loadConfig } from "./shared";
 
 const log = createLogger({ module: "deploy" });
@@ -41,6 +43,33 @@ interface DeployOptions {
     dryRun: boolean;
 }
 
+/**
+ * Synchronously write to stdout (fd 1). Unlike process.stdout.write (async on a
+ * pipe) this is guaranteed flushed before process.exit(), so `--help`/`--version`
+ * output is never truncated when the bin's stdout is a pipe (issue #68).
+ */
+function writeStdoutSync(text: string): void {
+    writeSync(1, text);
+}
+
+/**
+ * Reads the CLI version from the package manifest. Works from both the source
+ * layout (src/cli/deploy.ts) and the bundled layout (dist/cli/kn-next.js) —
+ * package.json sits two directories up in both cases.
+ */
+function getCliVersion(): string {
+    try {
+        const here = fileURLToPath(import.meta.url);
+        const pkgPath = resolve(here, "..", "..", "..", "package.json");
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+            version?: string;
+        };
+        return pkg.version ?? "0.0.0";
+    } catch {
+        return "0.0.0";
+    }
+}
+
 function parseCliArgs(): DeployOptions {
     const { values } = parseArgs({
         options: {
@@ -52,14 +81,27 @@ function parseCliArgs(): DeployOptions {
             "skip-upload": { type: "boolean", default: false },
             "dry-run": { type: "boolean", default: false },
             help: { type: "boolean", short: "h", default: false },
+            version: { type: "boolean", short: "v", default: false },
         },
         strict: true,
         allowPositionals: true,
     });
 
+    if (values.version) {
+        // Resolve version from the package manifest without bundling it inline,
+        // so the published version is always the source of truth.
+        writeStdoutSync(`${getCliVersion()}\n`);
+        process.exit(0);
+    }
+
     if (values.help) {
-        log.info(
-            [
+        // Write help synchronously to fd 1 — NOT via the async pino-pretty
+        // transport (flushed after process.exit, swallowing output) and NOT via
+        // process.stdout.write (async on a pipe, truncated by process.exit).
+        // fs.writeSync(1, …) is guaranteed flushed before exit, so `npx kn-next
+        // --help | cat` works under plain node (issue #68).
+        writeStdoutSync(
+            `${[
                 "kn-next deploy — build → push → apply NextApp CR",
                 "",
                 "Options:",
@@ -71,7 +113,8 @@ function parseCliArgs(): DeployOptions {
                 "  --skip-upload   Skip asset upload step",
                 "  --dry-run       Print the NextApp CR without applying it",
                 "  -h, --help      Show this help",
-            ].join("\n"),
+                "  -v, --version   Print the kn-next version",
+            ].join("\n")}\n`,
         );
         process.exit(0);
     }
@@ -123,7 +166,7 @@ async function deploy() {
         const assetPrefix = getAssetPrefix(config.storage);
         process.env.ASSET_PREFIX = assetPrefix;
         log.info({ assetPrefix }, "Running next build (output:standalone)...");
-        await $`npm run build`.quiet();
+        runQuiet(["npm", "run", "build"]);
         log.info(
             "Next.js build complete — standalone output in .next/standalone/",
         );
@@ -169,7 +212,22 @@ async function deploy() {
             (async () => {
                 const repoRoot = resolve(process.cwd(), "../..");
                 // --metadata-file writes the buildx result JSON (includes containerimage.digest).
-                await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${taggedRef} --push --metadata-file ${metadataFilePath} ${repoRoot}`;
+                // ARGV array, no shell — taggedRef etc. arrive as single tokens.
+                runInherit([
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--platform",
+                    "linux/amd64",
+                    "-f",
+                    `${process.cwd()}/Dockerfile`,
+                    "-t",
+                    taggedRef,
+                    "--push",
+                    "--metadata-file",
+                    metadataFilePath,
+                    repoRoot,
+                ]);
                 log.info("Docker image built and pushed");
             })(),
         );
@@ -181,14 +239,11 @@ async function deploy() {
         // FALLBACK: docker inspect --format '{{index .RepoDigests 0}}' (if metadata missing).
         // The operator's validateImageRef rejects any ref without @sha256:.
         log.info({ taggedRef }, "Resolving @sha256: digest...");
-        const { readFileSync } = await import("node:fs");
-        // ExecFn takes an ARGV array — no shell, no injection risk.
-        // Bun.spawn() bypasses sh entirely; each element is a separate argv token.
-        const execFn = async (argv: string[]): Promise<string> => {
-            const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
-            await proc.exited;
-            return new Response(proc.stdout).text();
-        };
+        // ExecFn takes an ARGV array — no shell, no injection risk (CLI-58).
+        // runCapture spawns via execFileSync with shell:false, so each element
+        // is a separate, uninterpreted argv token — never concatenated into sh.
+        const execFn = async (argv: string[]): Promise<string> =>
+            runCapture(argv);
         const readFileFn = (p: string) => readFileSync(p, "utf-8");
         imageRef = await resolveDigest(
             taggedRef,
@@ -222,20 +277,31 @@ async function deploy() {
     writeFileSync(crPath, crYaml, "utf-8");
 
     log.info({ cr: crPath }, "Applying NextApp CR to cluster...");
-    await $`kubectl apply -f ${crPath} -n ${options.namespace}`;
+    runInherit(["kubectl", "apply", "-f", crPath, "-n", options.namespace]);
 
     // Wait briefly for the operator to begin reconciling, then read the URL.
-    const result =
-        await $`kubectl get nextapp ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
+    const result = runCapture([
+        "kubectl",
+        "get",
+        "nextapp",
+        config.name,
+        "-n",
+        options.namespace,
+        "-o",
+        "jsonpath={.status.url}",
+    ]);
     log.info(
         { url: result.replace(/'/g, "") },
         "Deployment submitted — operator is reconciling",
     );
 }
 
-try {
-    await deploy();
-} catch (err) {
-    log.fatal({ err }, "Deployment failed");
-    process.exit(1);
+// Run only when invoked directly as the entry (not when imported, e.g. in tests).
+if (isEntrypoint(import.meta.url)) {
+    try {
+        await deploy();
+    } catch (err) {
+        log.fatal({ err }, "Deployment failed");
+        process.exit(1);
+    }
 }

--- a/packages/kn-next/src/cli/exec.ts
+++ b/packages/kn-next/src/cli/exec.ts
@@ -1,0 +1,121 @@
+/**
+ * exec.ts — node:child_process exec helpers for the kn-next CLI.
+ *
+ * Replaces Bun's `$` shell-template tag. Every former `` $`a b ${c}` `` call
+ * becomes an ARGV array `["a", "b", c]` passed to one of these helpers.
+ *
+ * SECURITY (CLI-58): all helpers run with **`shell: false`** — the command is
+ * spawned directly via the OS exec, NOT through `/bin/sh`. Arguments are passed
+ * as a discrete argv array, so a value containing shell metacharacters
+ * (`;`, backtick, `$()`, spaces, newlines) arrives as a single, uninterpreted
+ * token and can never inject a second command. Do NOT reintroduce string-
+ * interpolated shell here.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Returns true when the module identified by `importMetaUrl` is being run as the
+ * process entry (i.e. `node <thisfile>`), false when it was imported (e.g. by a
+ * test). Node-correct replacement for Bun's `import.meta.main`.
+ *
+ * CRITICAL: npm installs the CLI bin as a SYMLINK (node_modules/.bin/kn-next →
+ * .../dist/cli/kn-next.js). When run via that symlink, `process.argv[1]` is the
+ * symlink path while `import.meta.url` resolves to the REAL file. Both sides are
+ * therefore passed through realpathSync so the comparison holds for symlinked
+ * bins — without this, the entry guard never fires and the CLI silently no-ops.
+ */
+export function isEntrypoint(importMetaUrl: string): boolean {
+    const argv1 = process.argv[1];
+    if (!argv1) {
+        return false;
+    }
+    try {
+        const self = realpathSync(fileURLToPath(importMetaUrl));
+        const invoked = realpathSync(resolve(argv1));
+        return self === invoked;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Run a command (argv array) and CAPTURE its stdout as a trimmed string.
+ *
+ * No shell. argv[0] is the binary; argv[1..] are arguments. stderr is inherited
+ * so failures are visible; a non-zero exit throws (execFileSync semantics).
+ *
+ * @param argv - command + args, e.g. ["docker", "inspect", ref]
+ * @returns trimmed stdout
+ */
+export function runCapture(argv: readonly string[]): string {
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+        throw new Error("runCapture: empty argv");
+    }
+    const out = execFileSync(cmd, args, {
+        shell: false,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "inherit"],
+        maxBuffer: 64 * 1024 * 1024,
+    });
+    return out.toString().trim();
+}
+
+/**
+ * Run a command (argv array) and INHERIT stdio (stream child output straight to
+ * the terminal). No captured value. A non-zero exit throws.
+ *
+ * @param argv - command + args, e.g. ["kubectl", "apply", "-f", path]
+ */
+export function runInherit(argv: readonly string[]): void {
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+        throw new Error("runInherit: empty argv");
+    }
+    execFileSync(cmd, args, {
+        shell: false,
+        stdio: "inherit",
+        maxBuffer: 64 * 1024 * 1024,
+    });
+}
+
+/**
+ * Run a command (argv array) QUIETLY — discard stdout, inherit stderr. A
+ * non-zero exit throws. Use where the former code called `.quiet()` purely to
+ * silence stdout.
+ *
+ * @param argv - command + args
+ */
+export function runQuiet(argv: readonly string[]): void {
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+        throw new Error("runQuiet: empty argv");
+    }
+    execFileSync(cmd, args, {
+        shell: false,
+        stdio: ["ignore", "ignore", "inherit"],
+        maxBuffer: 64 * 1024 * 1024,
+    });
+}
+
+/**
+ * Like {@link runQuiet} but TOLERATES a non-zero exit (does not throw). Mirrors
+ * the old `... || true` shell idiom used for best-effort cleanup deletes.
+ *
+ * @param argv - command + args
+ */
+export function runQuietAllowFail(argv: readonly string[]): void {
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+        throw new Error("runQuietAllowFail: empty argv");
+    }
+    spawnSync(cmd, args, {
+        shell: false,
+        stdio: ["ignore", "ignore", "inherit"],
+        maxBuffer: 64 * 1024 * 1024,
+    });
+}

--- a/packages/kn-next/src/utils/asset-upload.ts
+++ b/packages/kn-next/src/utils/asset-upload.ts
@@ -1,8 +1,17 @@
 import { readdirSync } from "node:fs";
 import { join, relative } from "node:path";
-import { $ } from "bun";
+import { runCapture, runQuiet } from "../cli/exec";
 import type { KnativeNextConfig, StorageConfig } from "../config";
 import { createLogger } from "./logger";
+
+/**
+ * Lists the top-level entries inside a directory as absolute paths. Used to
+ * emulate a former shell glob (`dir/*`) without invoking a shell — each entry
+ * is passed as a discrete argv element (no shell expansion, no injection).
+ */
+function topLevelEntries(dir: string): string[] {
+    return readdirSync(dir).map((name) => join(dir, name));
+}
 
 const log = createLogger({ module: "asset-upload" });
 
@@ -50,15 +59,36 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
 
     switch (config.storage.provider) {
         case "gcs": {
-            // Upload with cache-control headers for immutable _next/static assets
-            await $`gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" cp -r ${assetsDir}/* gs://${config.storage.bucket}/`.quiet();
+            // Upload with cache-control headers for immutable _next/static assets.
+            // The former shell glob `${assetsDir}/*` is expanded in Node (no shell)
+            // and each top-level entry passed as a discrete argv source.
+            runQuiet([
+                "gsutil",
+                "-m",
+                "-h",
+                "Cache-Control:public, max-age=31536000, immutable",
+                "cp",
+                "-r",
+                ...topLevelEntries(assetsDir),
+                `gs://${config.storage.bucket}/`,
+            ]);
             // Ensure bucket has public read access for browser fetches
-            await $`gsutil iam ch allUsers:objectViewer gs://${config.storage.bucket}`.quiet();
+            runQuiet([
+                "gsutil",
+                "iam",
+                "ch",
+                "allUsers:objectViewer",
+                `gs://${config.storage.bucket}`,
+            ]);
 
             // Post-upload verification: ensure all local files exist in GCS
             const localFiles = collectFiles(assetsDir, assetsDir);
-            const gcsListResult =
-                await $`gsutil ls -r "gs://${config.storage.bucket}/"`.text();
+            const gcsListResult = runCapture([
+                "gsutil",
+                "ls",
+                "-r",
+                `gs://${config.storage.bucket}/`,
+            ]);
             const gcsFiles = new Set(
                 gcsListResult
                     .split("\n")
@@ -78,7 +108,14 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
                 for (const file of missing) {
                     const localPath = join(assetsDir, file);
                     const gcsPath = `gs://${config.storage.bucket}/${file}`;
-                    await $`gsutil -h "Cache-Control:public, max-age=31536000, immutable" cp ${localPath} ${gcsPath}`.quiet();
+                    runQuiet([
+                        "gsutil",
+                        "-h",
+                        "Cache-Control:public, max-age=31536000, immutable",
+                        "cp",
+                        localPath,
+                        gcsPath,
+                    ]);
                 }
                 log.info(
                     { count: missing.length },
@@ -88,14 +125,38 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
             break;
         }
         case "s3":
-            await $`aws s3 sync ${assetsDir} s3://${config.storage.bucket} --cache-control "public, max-age=31536000, immutable"`.quiet();
+            runQuiet([
+                "aws",
+                "s3",
+                "sync",
+                assetsDir,
+                `s3://${config.storage.bucket}`,
+                "--cache-control",
+                "public, max-age=31536000, immutable",
+            ]);
             break;
         case "minio":
-            // MinIO uses S3-compatible CLI
-            await $`mc cp --recursive ${assetsDir}/* minio/${config.storage.bucket}/`.quiet();
+            // MinIO uses S3-compatible CLI. Former shell glob `${assetsDir}/*`
+            // expanded in Node so each top-level entry is a discrete argv source.
+            runQuiet([
+                "mc",
+                "cp",
+                "--recursive",
+                ...topLevelEntries(assetsDir),
+                `minio/${config.storage.bucket}/`,
+            ]);
             break;
         case "azure":
-            await $`az storage blob upload-batch -d ${config.storage.bucket} -s ${assetsDir}`.quiet();
+            runQuiet([
+                "az",
+                "storage",
+                "blob",
+                "upload-batch",
+                "-d",
+                config.storage.bucket,
+                "-s",
+                assetsDir,
+            ]);
             break;
         default:
             throw new Error(

--- a/packages/kn-next/tsup.config.ts
+++ b/packages/kn-next/tsup.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from "tsup";
+
+/**
+ * tsup build for the kn-next CLI (issue #68).
+ *
+ * Produces runnable, Node-only JS for the three CLI entries so an outside user
+ * with no Bun installed can `npx kn-next`. The `bin.kn-next` in package.json
+ * points at the bundled `dist/cli/kn-next.js` (the deploy entry — unchanged
+ * behavior; deploy is what `kn-next` has always run).
+ *
+ * Runtime + workspace deps are EXTERNALIZED so they resolve from the published
+ * package's own `dependencies` at install time rather than being inlined.
+ */
+export default defineConfig({
+    entry: {
+        // dist/cli/kn-next.js — the bin (deploy entry)
+        "cli/kn-next": "src/cli/deploy.ts",
+        // also ship runnable build/cleanup entries
+        "cli/build": "src/cli/build.ts",
+        "cli/cleanup": "src/cli/cleanup.ts",
+    },
+    format: ["esm"],
+    platform: "node",
+    target: "node20",
+    outDir: "dist",
+    // The source CLI entries carry `#!/usr/bin/env node`; esbuild preserves it on
+    // the entry output. We deliberately do NOT add a banner shebang here — doing
+    // so would (a) duplicate the entry shebang and (b) wrongly prepend `#!` to the
+    // shared chunk files. Entry shebang only is exactly what a Node bin needs.
+    clean: true,
+    sourcemap: true,
+    // Do not bundle these — resolve from the package's deps at install time.
+    external: [
+        "@knext/lib",
+        "ioredis",
+        "yaml",
+        "pino",
+        "pino-pretty",
+        "prom-client",
+        "kafkajs",
+        "@google-cloud/storage",
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       minio:
         specifier: ^8.0.6
         version: 8.0.6
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       turbo:
         specifier: latest
         version: 2.9.18
@@ -2234,6 +2237,9 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -2339,6 +2345,16 @@ packages:
   bun-types@1.3.9:
     resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2373,6 +2389,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -2428,8 +2448,19 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -2671,6 +2702,9 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -3086,6 +3120,17 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3193,6 +3238,9 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -3213,6 +3261,9 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3283,6 +3334,10 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3440,9 +3495,34 @@ packages:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -3540,6 +3620,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -3710,6 +3794,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -3794,6 +3882,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3834,6 +3927,13 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
@@ -3849,6 +3949,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -3895,11 +3998,37 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   turbo@2.9.18:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
@@ -3913,6 +4042,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -5917,8 +6049,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  acorn@8.16.0:
-    optional: true
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5946,6 +6077,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  any-promise@1.3.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -6045,6 +6178,13 @@ snapshots:
     dependencies:
       '@types/node': 20.19.33
 
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6101,6 +6241,10 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
@@ -6144,7 +6288,13 @@ snapshots:
   commander@2.20.3:
     optional: true
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   constant-case@2.0.0:
     dependencies:
@@ -6415,6 +6565,12 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.57.1
 
   flatted@3.3.3: {}
 
@@ -6908,6 +7064,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -7008,6 +7170,13 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   module-details-from-path@1.0.4: {}
 
   mri@1.2.0: {}
@@ -7019,6 +7188,12 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -7096,6 +7271,8 @@ snapshots:
       resolve: 1.22.11
 
   node-releases@2.0.27: {}
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -7267,7 +7444,23 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.6
+      yaml: 2.8.2
 
   postcss@8.4.31:
     dependencies:
@@ -7371,6 +7564,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
 
@@ -7609,6 +7804,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7682,6 +7879,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7726,6 +7933,14 @@ snapshots:
       source-map-support: 0.5.21
     optional: true
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -7741,6 +7956,8 @@ snapshots:
   through@2.3.8: {}
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -7782,9 +7999,41 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   turbo@2.9.18:
     optionalDependencies:
@@ -7798,6 +8047,8 @@ snapshots:
   type-fest@0.21.3: {}
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/scripts/smoke-pack-cli.mjs
+++ b/scripts/smoke-pack-cli.mjs
@@ -1,25 +1,19 @@
 #!/usr/bin/env node
 /**
- * smoke-pack-cli.mjs — E1-1
+ * smoke-pack-cli.mjs — E1-1 / #68
  *
  * Proves the packed @knext/core artifact installs and exposes a working `kn-next` bin
- * for the SUPPORTED runtime (bun). The bin ships raw TS with a `#!/usr/bin/env bun`
- * shebang and imports `bun`, so it can ONLY run under bun — never assume node can run it.
+ * for plain Node (no Bun required — issue #68). Since #68 the bin is bundled, Node-only
+ * JS (`dist/cli/kn-next.js`) with a `#!/usr/bin/env node` shebang, so `node <bin>` runs
+ * it directly. A Bun leg is kept as an OPTIONAL extra check when bun is on PATH.
  *
  * Steps:
- *   1. `npm pack` @knext/core -> tarball.
- *   2. Fresh temp dir, `npm init -y`, `npm i <tarball>`.
- *   3. Run the installed bin's `--help` under bun. Assert exit 0 and that output
+ *   1. `pnpm pack` @knext/lib + @knext/core -> tarballs.
+ *   2. Fresh temp dir, `npm init -y`, `npm i <tarballs>`.
+ *   3. Run the installed bin's `--help` under NODE. Assert exit 0 and that output
  *      mentions "kn-next" or "Usage".
- *
- * Runtime policy:
- *   - bun NOT on PATH -> print SKIP and exit 0 (don't fail a host without bun).
- *   - bun present and `--help` exits non-zero -> FAIL (exit 1).
- *
- * NOTE: at time of writing the bin may not have a dedicated `--help` handler yet
- * (another worker is adding it). This script EXPECTS `--help` to exit 0. If it exits
- * non-zero (e.g. a "no config found" error), that is reported as a FAIL so we can tell
- * the help handler isn't wired — it is NOT worked around.
+ *   4. If bun is present, ALSO run `--help` under bun (optional leg; failure there
+ *      is reported but does not change the primary node result).
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -34,7 +28,6 @@ const corePkgDir = join(repoRoot, 'packages', 'kn-next');
 const libPkgDir = join(repoRoot, 'packages', 'lib');
 
 const PASS = 'PASS';
-const SKIP = 'SKIP';
 const FAIL = 'FAIL';
 
 /** Print a final summary line and exit with the matching code. */
@@ -88,6 +81,13 @@ try {
     cwd: repoRoot,
     stdio: ['ignore', 'inherit', 'inherit'],
   });
+  // #68: @knext/core now ships a bundled dist/ bin — build it before packing or the
+  // tarball has no dist/cli/kn-next.js and the bin symlink is broken.
+  console.log('[smoke:cli] building @knext/core (ships dist/ bin) ...');
+  execFileSync('pnpm', ['--filter', '@knext/core', 'build'], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
   libDest = mkdtempSync(join(tmpdir(), 'knext-pack-lib-'));
   coreDest = mkdtempSync(join(tmpdir(), 'knext-pack-core-'));
   const libTarball = pnpmPack(libPkgDir, libDest, '@knext/lib');
@@ -113,16 +113,9 @@ try {
     finish(FAIL, `installed bin not found at ${binPath}`);
   }
 
-  // --- 3. run --help under bun ----------------------------------------------
-  if (!hasBun()) {
-    finish(
-      SKIP,
-      'bun not on PATH; the kn-next bin is bun-only, so the help check was skipped (host not failed)',
-    );
-  }
-
-  console.log('[smoke:cli] running `bun <bin> --help` ...');
-  const run = spawnSync('bun', [binPath, '--help'], {
+  // --- 3. run --help under NODE (primary — #68) -----------------------------
+  console.log('[smoke:cli] running `node <bin> --help` ...');
+  const run = spawnSync('node', [binPath, '--help'], {
     cwd: workDir,
     encoding: 'utf8',
   });
@@ -134,7 +127,7 @@ try {
   if (run.status !== 0) {
     finish(
       FAIL,
-      `bun kn-next --help exited ${run.status} (expected 0). ` +
+      `node kn-next --help exited ${run.status} (expected 0). ` +
         "If this is a 'no config'-type error, the --help handler is not wired yet.",
     );
   }
@@ -144,7 +137,26 @@ try {
     finish(FAIL, "exit 0 but output did not contain 'kn-next' or 'Usage'");
   }
 
-  finish(PASS, 'packed @knext/core installs and `kn-next --help` works under bun');
+  // --- 4. optional bun leg --------------------------------------------------
+  // Bun is no longer required; run it only as a bonus check when present.
+  if (hasBun()) {
+    console.log('[smoke:cli] (optional) running `bun <bin> --help` ...');
+    const bunRun = spawnSync('bun', [binPath, '--help'], {
+      cwd: workDir,
+      encoding: 'utf8',
+    });
+    if (bunRun.status !== 0) {
+      console.log(
+        `[smoke:cli] WARNING: optional bun leg exited ${bunRun.status} (node leg already passed)`,
+      );
+    } else {
+      console.log('[smoke:cli] optional bun leg also passed');
+    }
+  } else {
+    console.log('[smoke:cli] bun not on PATH — skipping optional bun leg');
+  }
+
+  finish(PASS, 'packed @knext/core installs and `kn-next --help` works under node');
 } catch (err) {
   finish(FAIL, `unexpected error: ${err?.message ? err.message : err}`);
 } finally {


### PR DESCRIPTION
Closes #68.

The CLI was Bun-only (shebangs, `import { \$ } from \"bun\"`, `Bun.spawn`) and shipped raw `.ts`, so a Node-only user could not run `npx kn-next`. This ports all three entries (deploy/build/cleanup) + asset-upload to `node:child_process`.

**Security:** a new `exec.ts` helper runs every command with `shell:false` + an argv array — no interpolated value can reach a shell. The CLI-58 injection fix is preserved (`validateTaggedRef` + the no-shell argv boundary). Independent security review: APPROVE.

**Packaging:** a `tsup` build emits `dist/cli/kn-next.js` with a `#!/usr/bin/env node` shebang; `bin`→`dist`, runtime deps externalized + declared. `isEntrypoint` realpaths both sides so the npm-symlinked bin fires correctly. Adds `--version`.

**Verified:** build + `node <bin> --help/--version` (no Bun) + typecheck + 63/63 tests + pack-smoke under node all green.

This is the last code blocker for `npx kn-next` — only the actual `npm publish` (your token, #53) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)