### PR TITLE
Run the kn-next CLI on plain Node (un-block npx kn-next) (#68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,61 @@ jobs:
           RUNTIME: ${{ matrix.runtime }}
         run: node scripts/compat-smoke.mjs
 
+  cli-node-smoke:
+    # #68 — the kn-next CLI must run on plain Node (un-block `npx kn-next`).
+    # Builds @knext/core to an EMITTED JS bin and runs `deploy --dry-run` on
+    # BOTH Node and Bun. The Node leg deliberately does NOT install Bun, so a
+    # green Node run proves the CLI no longer needs Bun. Mirrors the compat-smoke
+    # node+bun matrix. Asserts the dry-run prints a NextApp CR (no cluster).
+    name: kn-next CLI smoke (Node + Bun)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [node, bun]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      # Bun is installed ONLY for the bun leg. The node leg has no Bun on PATH,
+      # which is exactly what proves the CLI runs without it.
+      - name: Setup Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Emit the runnable JS bin (typecheck + esbuild bundle). No Bun required.
+      - name: Build @knext/core CLI (emit JS bin)
+        run: pnpm --filter @knext/core build
+
+      - name: Run `<runtime> <emitted-bin> deploy --dry-run` and assert a NextApp CR
+        working-directory: packages/kn-next/src/__tests__/fixtures/cli-68
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="$GITHUB_WORKSPACE/packages/kn-next/dist/cli/deploy.js"
+          test -f "$BIN" || { echo "emitted bin missing: $BIN"; exit 1; }
+          echo "runtime=${{ matrix.runtime }}"
+          OUT="$(${{ matrix.runtime }} "$BIN" deploy --dry-run)"
+          echo "$OUT"
+          echo "$OUT" | grep -q 'kind: NextApp' \
+            || { echo 'FAIL: dry-run did not print a NextApp CR'; exit 1; }
+          echo "$OUT" | grep -q 'minScale: 0' \
+            || { echo 'FAIL: scale-to-zero (minScale: 0) missing from CR'; exit 1; }
+
   no-latest-guard:
     name: No :latest images in operator manifests
     runs-on: ubuntu-latest

--- a/packages/kn-next/package.json
+++ b/packages/kn-next/package.json
@@ -6,7 +6,7 @@
   "main": "./src/config.ts",
   "types": "./src/config.ts",
   "bin": {
-    "kn-next": "./src/cli/deploy.ts"
+    "kn-next": "./dist/cli/deploy.js"
   },
   "exports": {
     ".": "./src/config.ts",
@@ -18,8 +18,9 @@
     "./cli/shared": "./src/cli/shared.ts"
   },
   "scripts": {
-    "build": "tsc --noEmit",
-    "deploy": "bun run ./src/cli/deploy.ts",
+    "build": "tsc --noEmit && node scripts/build-cli.mjs",
+    "prepack": "node scripts/build-cli.mjs",
+    "deploy": "node ./dist/cli/deploy.js",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "typecheck": "tsc --noEmit",
@@ -27,7 +28,11 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
+    "dist",
     "src"
   ],
   "keywords": [
@@ -46,6 +51,7 @@
     "@types/node": "^25.3.0",
     "@vitest/coverage-v8": "^4.0.18",
     "bun-types": "^1.3.9",
+    "esbuild": "^0.27.3",
     "vitest": "^4.0.18"
   },
   "dependencies": {

--- a/packages/kn-next/scripts/build-cli.mjs
+++ b/packages/kn-next/scripts/build-cli.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * build-cli.mjs (#68) — emit runnable JS for the kn-next CLI.
+ *
+ * Why esbuild and not bare `tsc`:
+ *   The package source uses extensionless relative imports (`./exec`,
+ *   `../config`) under TS `moduleResolution: "bundler"`. Plain `tsc` emit keeps
+ *   those specifiers verbatim, which Node ESM rejects (it requires `./exec.js`).
+ *   Rewriting every import across the package would be a large, out-of-scope
+ *   change. esbuild bundles each CLI entry into a single self-contained ESM
+ *   file with all relative deps inlined and `node:`/npm deps left external —
+ *   so `node dist/cli/deploy.js` runs with no Bun and no extension fixups.
+ *
+ * Runtime safety: the bundle contains NO `import ... from "bun"` and NO
+ * `Bun.*` — the CLI source was ported to `node:child_process` (see cli/exec.ts).
+ * Bun stays supported because `node:child_process` works on both runtimes.
+ */
+
+import { build } from "esbuild";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(here, "..");
+const srcCli = join(pkgDir, "src", "cli");
+const outDir = join(pkgDir, "dist", "cli");
+
+/** CLI entry points that get a `#!/usr/bin/env node` shebang + chmod +x. */
+const ENTRIES = ["deploy.ts", "build.ts", "cleanup.ts"];
+
+await build({
+    entryPoints: ENTRIES.map((f) => join(srcCli, f)),
+    outdir: outDir,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node20",
+    // Keep node builtins and npm deps external — only inline our own relative
+    // source. `--packages=external` leaves every bare specifier (pino, yaml,
+    // @google-cloud/storage, …) as a runtime `import`, resolved from
+    // node_modules at install time.
+    packages: "external",
+    logLevel: "info",
+});
+
+// esbuild preserves the entry file's first-line shebang. Our source CLIs now
+// start with `#!/usr/bin/env node`, so the emitted bin is a Node script. Assert
+// it — a wrong/missing/duplicated shebang silently breaks `npx kn-next`.
+for (const f of ENTRIES) {
+    const out = join(outDir, f.replace(/\.ts$/, ".js"));
+    const firstLine = readFileSync(out, "utf-8").split("\n", 1)[0];
+    if (firstLine !== "#!/usr/bin/env node") {
+        throw new Error(
+            `build-cli: ${out} first line is "${firstLine}", expected "#!/usr/bin/env node".`,
+        );
+    }
+}
+
+// Mark the emitted entry files executable (npm does this for `bin` on install,
+// but a local `node dist/cli/deploy.js` and direct `./dist/cli/deploy.js` both
+// benefit from the +x bit being set).
+for (const f of ENTRIES) {
+    const out = join(outDir, f.replace(/\.ts$/, ".js"));
+    chmodSync(out, 0o755);
+}
+
+// Sanity guard: the emitted deploy bin must be Bun-free (acceptance criterion).
+const deployJs = readFileSync(join(outDir, "deploy.js"), "utf-8");
+if (/from\s*["']bun["']/.test(deployJs) || /\bBun\.\w/.test(deployJs)) {
+    // Re-stringify so the failure is loud in CI; never ship a Bun-coupled bin.
+    writeFileSync(join(outDir, "deploy.js"), deployJs);
+    throw new Error(
+        "build-cli: emitted dist/cli/deploy.js still references Bun — refusing to ship.",
+    );
+}
+
+console.log("[build-cli] emitted:", ENTRIES.map((f) => f.replace(/\.ts$/, ".js")).join(", "));

--- a/packages/kn-next/src/__tests__/cli-68-exec.test.ts
+++ b/packages/kn-next/src/__tests__/cli-68-exec.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #68 — portable shell helper (Node child_process, argv arrays).
+ *
+ * The kn-next CLI must run on plain Node (no Bun). The shell helper that
+ * replaces `import { $ } from "bun"` / `Bun.spawn` must:
+ *   1. Run a real command via an ARGV array and return its stdout (capture()).
+ *   2. NEVER interpret shell metacharacters — each argv element is a single,
+ *      uninterpreted token. This is the injection-safety guarantee that
+ *      `Bun.$` provided via auto-escaping and that we must reproduce.
+ *   3. Reject a non-zero exit with an error that carries the exit code.
+ *   4. Expose nothing from the "bun" module — the helper is Node-native.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { capture, run } from "../cli/exec";
+
+describe("#68 exec helper — capture()", () => {
+    it("returns stdout for a real command via an argv array", async () => {
+        const out = await capture(["node", "-e", "process.stdout.write('hi')"]);
+        expect(out).toBe("hi");
+    });
+
+    it("treats a metacharacter-laden argument as ONE uninterpreted token (no shell injection)", async () => {
+        // If this were concatenated into a shell string, `$(whoami)` and `` `id` ``
+        // would be command-substituted and `; touch …` would run a 2nd command.
+        // With an argv array the whole thing is ONE literal argument echoed back
+        // verbatim — proving no shell interpretation happened. The marker we
+        // expect NOT to see is the OUTPUT of any substituted command, so we
+        // build it from a unique token that only appears if a shell ran it.
+        const sentinel = "INJECTED_BY_SHELL";
+        const payload = `value; echo ${sentinel}; $(echo ${sentinel}) \`echo ${sentinel}\``;
+        const out = await capture([
+            "node",
+            "-e",
+            "process.stdout.write(process.argv[1])",
+            payload,
+        ]);
+        // Output is EXACTLY the payload — the literal string, unmodified.
+        expect(out).toBe(payload);
+        // If a shell had run, `$(echo X)`/`` `echo X` `` would collapse to `X`,
+        // so the payload would no longer contain the literal `$(echo …)` form.
+        // Its survival proves no substitution occurred.
+        expect(out).toContain(`$(echo ${sentinel})`);
+        expect(out).toContain(`\`echo ${sentinel}\``);
+    });
+
+    it("does not expand a glob or variable passed as an argument", async () => {
+        const out = await capture([
+            "node",
+            "-e",
+            "process.stdout.write(process.argv[1])",
+            "*; $HOME",
+        ]);
+        expect(out).toBe("*; $HOME");
+    });
+
+    it("rejects on a non-zero exit code", async () => {
+        await expect(
+            capture(["node", "-e", "process.exit(3)"]),
+        ).rejects.toThrow(/exit|code|3/i);
+    });
+});
+
+describe("#68 exec helper — run()", () => {
+    it("resolves (to undefined) on exit 0", async () => {
+        // run() resolves with no value on success. Assert the resolution
+        // directly — chaining `.resolves.not.toThrow()` misuses toThrow (a
+        // function-matcher) against an already-resolved value, which some
+        // runners (bun test) correctly reject.
+        await expect(
+            run(["node", "-e", "process.exit(0)"]),
+        ).resolves.toBeUndefined();
+    });
+
+    it("rejects on a non-zero exit", async () => {
+        await expect(run(["node", "-e", "process.exit(1)"])).rejects.toThrow(
+            /exit|code|1/i,
+        );
+    });
+});
+
+describe("#68 exec module is Node-native (no bun import)", () => {
+    it("exec.ts source imports node:child_process and not the bun module", () => {
+        const src = readFileSync(
+            join(__dirname, "..", "cli", "exec.ts"),
+            "utf-8",
+        );
+        expect(src).toContain("node:child_process");
+        // No `from "bun"` import in actual CODE (the docstring may mention what
+        // it replaces, so strip comments before matching).
+        const code = src
+            .replace(/\/\*[\s\S]*?\*\//g, "")
+            .replace(/(^|[^:])\/\/.*$/gm, "$1");
+        expect(code).not.toMatch(/import[^;]*from\s+["']bun["']/);
+    });
+});

--- a/packages/kn-next/src/__tests__/cli-68-node-bin.test.ts
+++ b/packages/kn-next/src/__tests__/cli-68-node-bin.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #68 — the kn-next CLI runs on plain Node and the bin is an emitted JS entry.
+ *
+ * Acceptance criteria (issue #68):
+ *  - `node <emitted-bin> deploy --dry-run` runs with NO Bun and prints a NextApp CR.
+ *  - No `import ... from "bun"` / `Bun.` on the Node code path in src/cli/.
+ *  - package.json `bin.kn-next` resolves to an EMITTED JS entry (a build step),
+ *    not raw .ts.
+ *
+ * These tests shell out to a real `node` (never bun) so they prove the Node
+ * code path end-to-end. The build step is invoked from the test so the emitted
+ * bin always reflects the current source.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const pkgDir = resolve(__dirname, "..", "..");
+const cliDir = resolve(__dirname, "..", "cli");
+
+/** Strip // line comments and block comments so comment text isn't matched. */
+function stripComments(src: string): string {
+    return src
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/** Read pkg.bin.kn-next and resolve it to an absolute path. */
+function binEntry(): { rel: string; abs: string } {
+    const pkg = JSON.parse(
+        readFileSync(join(pkgDir, "package.json"), "utf-8"),
+    ) as { bin?: Record<string, string> };
+    const rel = pkg.bin?.["kn-next"] ?? "";
+    return { rel, abs: resolve(pkgDir, rel) };
+}
+
+describe("#68 packaging — bin.kn-next is an emitted JS entry", () => {
+    it("package.json bin.kn-next points at a .js file, not raw .ts", () => {
+        const { rel } = binEntry();
+        expect(rel).toMatch(/\.js$/);
+        expect(rel).not.toMatch(/\.ts$/);
+        expect(rel).not.toMatch(/^\.\/src\//);
+    });
+
+    it("a build script that EMITS JS exists (not a bare --noEmit)", () => {
+        const pkg = JSON.parse(
+            readFileSync(join(pkgDir, "package.json"), "utf-8"),
+        ) as { scripts?: Record<string, string> };
+        const build = pkg.scripts?.build ?? "";
+        // Must invoke an emit step (esbuild bundler / tsup / emitting tsc).
+        // A *bare* `tsc --noEmit` with nothing after it produces nothing runnable;
+        // here typecheck (--noEmit) is chained with a real emit step.
+        expect(build).toMatch(/build-cli|tsup|esbuild/);
+        expect(build).not.toBe("tsc --noEmit");
+    });
+});
+
+describe("#68 source — no bun on the Node CLI code path", () => {
+    it("no src/cli/*.ts imports the bun module or references Bun. on the Node path", () => {
+        const files = readdirSync(cliDir).filter((f) => f.endsWith(".ts"));
+        const offenders: string[] = [];
+        for (const f of files) {
+            // Strip comments so doc/comment mentions of `bun` / `Bun.` (e.g. the
+            // ported helper explaining what it replaced) don't false-positive.
+            // Only real CODE references count.
+            const code = stripComments(readFileSync(join(cliDir, f), "utf-8"));
+            if (/import[^;]*from\s+["']bun["']/.test(code)) {
+                offenders.push(`${f}: imports "bun"`);
+            }
+            // `Bun.` used outside a runtime-guarded fallback is not allowed.
+            if (/\bBun\.\w/.test(code)) {
+                offenders.push(`${f}: references Bun.`);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it("shebangs on entry CLIs are #!/usr/bin/env node", () => {
+        for (const f of ["deploy.ts", "build.ts", "cleanup.ts"]) {
+            const first = readFileSync(join(cliDir, f), "utf-8").split("\n")[0];
+            expect(first).toBe("#!/usr/bin/env node");
+        }
+    });
+});
+
+describe("#68 runtime — node <emitted-bin> deploy --dry-run prints a NextApp CR", () => {
+    const { abs: binAbs } = binEntry();
+    const fixtureDir = join(pkgDir, "src", "__tests__", "fixtures", "cli-68");
+
+    beforeAll(() => {
+        // Emit JS so the bin reflects current source (no Bun involved).
+        execFileSync("npm", ["run", "build"], {
+            cwd: pkgDir,
+            stdio: "inherit",
+        });
+    }, 120_000);
+
+    it("emitted bin file exists after build", () => {
+        expect(existsSync(binAbs)).toBe(true);
+    });
+
+    it("runs under plain `node` and emits a valid NextApp CR to stdout", () => {
+        const run = spawnSync(
+            process.execPath,
+            [binAbs, "deploy", "--dry-run"],
+            {
+                cwd: fixtureDir,
+                encoding: "utf-8",
+                env: { ...process.env },
+            },
+        );
+
+        const out = `${run.stdout ?? ""}`;
+        // Must exit cleanly on the Node path.
+        expect(run.status).toBe(0);
+
+        // stdout carries the NextApp CR (deploy.ts writes the YAML via
+        // process.stdout.write in dry-run mode), interleaved with pretty logs.
+        // Extract the contiguous CR block: from `apiVersion:` up to the next
+        // pino-pretty log line (which starts with a `[HH:MM:SS]` timestamp).
+        const lines = out.split("\n");
+        const start = lines.findIndex((l) => l.startsWith("apiVersion:"));
+        expect(start).toBeGreaterThanOrEqual(0);
+        const rest = lines.slice(start);
+        const end = rest.findIndex((l, i) => i > 0 && /^\[\d{2}:\d{2}/.test(l));
+        const yamlBlock = (end === -1 ? rest : rest.slice(0, end)).join("\n");
+
+        const cr = YAML.parse(yamlBlock) as {
+            kind: string;
+            spec: { scaling: { minScale: number } };
+        };
+        expect(cr.kind).toBe("NextApp");
+        // Scale-to-zero invariant survives the Node path.
+        expect(cr.spec.scaling.minScale).toBe(0);
+    });
+});

--- a/packages/kn-next/src/__tests__/fixtures/cli-68/kn-next.config.ts
+++ b/packages/kn-next/src/__tests__/fixtures/cli-68/kn-next.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Fixture config for #68 — drives `node <emitted-bin> deploy --dry-run`.
+ * Plain object so it loads under plain Node (v24 strips types on import).
+ */
+export default {
+    name: "cli68-fixture-app",
+    registry: "registry.example.com/cli68",
+    storage: {
+        provider: "gcs",
+        bucket: "cli68-bucket",
+        publicUrl: "https://storage.googleapis.com/cli68-bucket",
+    },
+    cache: {
+        provider: "redis",
+        url: "redis://redis:6379",
+        keyPrefix: "cli68-fixture-app",
+    },
+    scaling: {
+        minScale: 0,
+        maxScale: 3,
+    },
+};

--- a/packages/kn-next/src/cli/build.ts
+++ b/packages/kn-next/src/cli/build.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 /**
  * kn-next build — Prepares Next.js app for Knative deployment.
  *
@@ -19,10 +19,11 @@
  * reconciles everything from the NextApp CR emitted by `deploy`.
  */
 
-import { $ } from "bun";
 import { uploadAssets } from "../utils/asset-upload";
 import { createLogger } from "../utils/logger";
-import { loadConfig } from "./shared";
+// Portable shell helper (#68) — Node-native, argv-array based, runs on Node + Bun.
+import { run } from "./exec";
+import { isMainModule, loadConfig } from "./shared";
 
 const log = createLogger({ module: "build" });
 
@@ -50,7 +51,7 @@ export async function build(options: BuildOptions = {}) {
     //    The app's next.config.ts must set output:'standalone'.
     if (!options.skipNextBuild) {
         log.info("Running next build (output:standalone)...");
-        await $`npm run build`.quiet();
+        await run(["npm", "run", "build"], { quiet: true });
         log.info(
             "Next.js build complete — standalone output in .next/standalone/",
         );
@@ -66,8 +67,8 @@ export async function build(options: BuildOptions = {}) {
     );
 }
 
-// Run if executed directly
-if (import.meta.main) {
+// Run if executed directly (portable across Node + Bun — no import.meta.main).
+if (isMainModule(import.meta.url)) {
     try {
         await build({
             skipNextBuild: process.argv.includes("--skip-next"),

--- a/packages/kn-next/src/cli/cleanup.ts
+++ b/packages/kn-next/src/cli/cleanup.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 /**
  * kn-next cleanup - Removes Knative services and clears storage
  *
@@ -11,9 +11,10 @@
  *   3. Clear storage bucket
  */
 
-import { $ } from "bun";
 import type { KnativeNextConfig } from "../config";
 import { createLogger } from "../utils/logger";
+// Portable shell helper (#68) — Node-native, argv-array based, runs on Node + Bun.
+import { run } from "./exec";
 // Single source of truth for config loading — also runs validateConfig,
 // which cleanup's former private copy skipped (CONFIG-LOAD-DEDUP).
 import { loadConfig } from "./shared";
@@ -37,7 +38,10 @@ async function cleanup() {
     // 2. Delete Knative service
     log.info("Deleting Knative service...");
     try {
-        await $`kubectl delete ksvc ${config.name} --ignore-not-found`.quiet();
+        await run(
+            ["kubectl", "delete", "ksvc", config.name, "--ignore-not-found"],
+            { quiet: true },
+        );
         log.info({ service: config.name }, "Deleted Knative service");
     } catch (_err) {
         log.warn("Service not found or already deleted");
@@ -46,21 +50,96 @@ async function cleanup() {
     // 3. Delete infrastructure services (if configured)
     if (config.infrastructure) {
         log.info("Deleting infrastructure services...");
+        const q = { quiet: true } as const;
         if (config.infrastructure.postgres?.enabled) {
-            await $`kubectl delete statefulset ${config.name}-postgres --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-postgres --ignore-not-found`.quiet();
-            await $`kubectl delete pvc -l app=${config.name}-postgres --ignore-not-found`.quiet();
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "statefulset",
+                    `${config.name}-postgres`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "svc",
+                    `${config.name}-postgres`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "pvc",
+                    "-l",
+                    `app=${config.name}-postgres`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
             log.info("Deleted PostgreSQL");
         }
         if (config.infrastructure.redis?.enabled) {
-            await $`kubectl delete deployment ${config.name}-redis --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-redis --ignore-not-found`.quiet();
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "deployment",
+                    `${config.name}-redis`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "svc",
+                    `${config.name}-redis`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
             log.info("Deleted Redis");
         }
         if (config.infrastructure.minio?.enabled) {
-            await $`kubectl delete statefulset ${config.name}-minio --ignore-not-found`.quiet();
-            await $`kubectl delete svc ${config.name}-minio --ignore-not-found`.quiet();
-            await $`kubectl delete pvc -l app=${config.name}-minio --ignore-not-found`.quiet();
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "statefulset",
+                    `${config.name}-minio`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "svc",
+                    `${config.name}-minio`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
+            await run(
+                [
+                    "kubectl",
+                    "delete",
+                    "pvc",
+                    "-l",
+                    `app=${config.name}-minio`,
+                    "--ignore-not-found",
+                ],
+                q,
+            );
             log.info("Deleted MinIO");
         }
     }
@@ -74,18 +153,35 @@ async function cleanup() {
 }
 
 async function clearStorage(config: KnativeNextConfig) {
+    const bucket = config.storage.bucket;
     switch (config.storage.provider) {
         case "gcs":
-            await $`gsutil -m rm -r gs://${config.storage.bucket}/** 2>/dev/null || true`.quiet();
+            // The former shell used `2>/dev/null || true` to swallow the
+            // "no URLs matched" error on an already-empty bucket. With an argv
+            // array there is no shell, so we tolerate the non-zero exit here.
+            try {
+                await run(["gsutil", "-m", "rm", "-r", `gs://${bucket}/**`], {
+                    quiet: true,
+                });
+            } catch {
+                // already empty / nothing matched — non-fatal, same as `|| true`.
+            }
             break;
         case "s3":
-            await $`aws s3 rm s3://${config.storage.bucket} --recursive`.quiet();
+            await run(["aws", "s3", "rm", `s3://${bucket}`, "--recursive"], {
+                quiet: true,
+            });
             break;
         case "minio":
-            await $`mc rm --recursive --force minio/${config.storage.bucket}`.quiet();
+            await run(
+                ["mc", "rm", "--recursive", "--force", `minio/${bucket}`],
+                { quiet: true },
+            );
             break;
         case "azure":
-            await $`az storage blob delete-batch -s ${config.storage.bucket}`.quiet();
+            await run(["az", "storage", "blob", "delete-batch", "-s", bucket], {
+                quiet: true,
+            });
             break;
     }
 }

--- a/packages/kn-next/src/cli/deploy.ts
+++ b/packages/kn-next/src/cli/deploy.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 /**
  * kn-next CLI — Knative Next.js Deployment Automation
  *
@@ -18,7 +18,6 @@
 
 import { join, resolve } from "node:path";
 import { parseArgs } from "node:util";
-import { $ } from "bun";
 import type { KnativeNextConfig } from "../config";
 import { getAssetPrefix, uploadAssets } from "../utils/asset-upload";
 import { createLogger } from "../utils/logger";
@@ -27,6 +26,9 @@ import {
     resolveDigest,
     validateCRImageRef,
 } from "./cr-builder";
+// Portable shell helper (#68): Node-native, argv-array based, no shell — runs
+// on plain Node and Bun. Replaces `import { $ } from "bun"` / `Bun.spawn`.
+import { capture, run } from "./exec";
 import { loadConfig } from "./shared";
 
 const log = createLogger({ module: "deploy" });
@@ -123,7 +125,7 @@ async function deploy() {
         const assetPrefix = getAssetPrefix(config.storage);
         process.env.ASSET_PREFIX = assetPrefix;
         log.info({ assetPrefix }, "Running next build (output:standalone)...");
-        await $`npm run build`.quiet();
+        await run(["npm", "run", "build"], { quiet: true });
         log.info(
             "Next.js build complete — standalone output in .next/standalone/",
         );
@@ -169,7 +171,22 @@ async function deploy() {
             (async () => {
                 const repoRoot = resolve(process.cwd(), "../..");
                 // --metadata-file writes the buildx result JSON (includes containerimage.digest).
-                await $`docker buildx build --platform linux/amd64 -f ${process.cwd()}/Dockerfile -t ${taggedRef} --push --metadata-file ${metadataFilePath} ${repoRoot}`;
+                // argv array — no shell, no injection (taggedRef/paths are single tokens).
+                await run([
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--platform",
+                    "linux/amd64",
+                    "-f",
+                    `${process.cwd()}/Dockerfile`,
+                    "-t",
+                    taggedRef,
+                    "--push",
+                    "--metadata-file",
+                    metadataFilePath,
+                    repoRoot,
+                ]);
                 log.info("Docker image built and pushed");
             })(),
         );
@@ -183,12 +200,9 @@ async function deploy() {
         log.info({ taggedRef }, "Resolving @sha256: digest...");
         const { readFileSync } = await import("node:fs");
         // ExecFn takes an ARGV array — no shell, no injection risk.
-        // Bun.spawn() bypasses sh entirely; each element is a separate argv token.
-        const execFn = async (argv: string[]): Promise<string> => {
-            const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
-            await proc.exited;
-            return new Response(proc.stdout).text();
-        };
+        // capture() spawns via node:child_process with shell:false; each element
+        // is a separate argv token (works on Node and Bun).
+        const execFn = (argv: string[]): Promise<string> => capture(argv);
         const readFileFn = (p: string) => readFileSync(p, "utf-8");
         imageRef = await resolveDigest(
             taggedRef,
@@ -222,11 +236,20 @@ async function deploy() {
     writeFileSync(crPath, crYaml, "utf-8");
 
     log.info({ cr: crPath }, "Applying NextApp CR to cluster...");
-    await $`kubectl apply -f ${crPath} -n ${options.namespace}`;
+    await run(["kubectl", "apply", "-f", crPath, "-n", options.namespace]);
 
     // Wait briefly for the operator to begin reconciling, then read the URL.
-    const result =
-        await $`kubectl get nextapp ${config.name} -n ${options.namespace} -o jsonpath='{.status.url}'`.text();
+    // jsonpath has no surrounding shell quotes here — argv passes it verbatim.
+    const result = await capture([
+        "kubectl",
+        "get",
+        "nextapp",
+        config.name,
+        "-n",
+        options.namespace,
+        "-o",
+        "jsonpath={.status.url}",
+    ]);
     log.info(
         { url: result.replace(/'/g, "") },
         "Deployment submitted — operator is reconciling",

--- a/packages/kn-next/src/cli/exec.ts
+++ b/packages/kn-next/src/cli/exec.ts
@@ -1,0 +1,127 @@
+/**
+ * exec.ts — portable shell helper for the kn-next CLI (#68).
+ *
+ * Replaces `import { $ } from "bun"` / `Bun.spawn(...)` so the CLI runs on
+ * plain Node as well as Bun. Backed by Node's `node:child_process.spawn`.
+ *
+ * INJECTION SAFETY (the Bun.$ guarantee we must reproduce):
+ *   Every command is invoked as an ARGV array — `spawn(cmd, args)` with
+ *   `shell: false` (the default). No string is ever handed to a shell, so
+ *   shell metacharacters (`;`, `|`, `$()`, backticks, `*`, spaces, …) inside
+ *   an argument are passed through verbatim as a single, uninterpreted token.
+ *   This is structurally injection-proof: there is no shell to inject into.
+ *   Do NOT add a `shell: true` option or build command strings here.
+ *
+ * Both Node and Bun implement `node:child_process`, so this single module
+ * works on both runtimes — Bun stays a first-class supported runtime.
+ */
+
+import { spawn } from "node:child_process";
+
+export interface ExecOptions {
+    /** Working directory for the spawned process. Defaults to process.cwd(). */
+    cwd?: string;
+    /**
+     * When true, suppress the child's stdout/stderr from being inherited by
+     * this process (mirrors Bun.$`...`.quiet()). Output is still captured and
+     * returned/available on error. Defaults to false (inherit stderr).
+     */
+    quiet?: boolean;
+    /** Extra environment variables merged over process.env. */
+    env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Error thrown when a spawned command exits non-zero. Carries the exit code,
+ * the argv, and captured stderr so callers can produce a clear failure.
+ */
+export class ExecError extends Error {
+    readonly code: number | null;
+    readonly argv: string[];
+    readonly stderr: string;
+
+    constructor(argv: string[], code: number | null, stderr: string) {
+        super(
+            `Command failed with exit code ${code}: ${argv.join(" ")}` +
+                (stderr ? `\n${stderr}` : ""),
+        );
+        this.name = "ExecError";
+        this.code = code;
+        this.argv = argv;
+        this.stderr = stderr;
+    }
+}
+
+/**
+ * Internal: spawn an argv with no shell and collect stdout/stderr.
+ * Rejects with ExecError on a non-zero exit (or spawn failure).
+ */
+function spawnArgv(
+    argv: string[],
+    options: ExecOptions,
+): Promise<{ stdout: string; stderr: string }> {
+    if (!Array.isArray(argv) || argv.length === 0) {
+        return Promise.reject(
+            new Error("exec: argv must be a non-empty string[]"),
+        );
+    }
+    const [cmd, ...args] = argv;
+
+    return new Promise((resolve, reject) => {
+        // shell:false (default) — argv elements are passed directly to the OS,
+        // never concatenated into a shell command line. This is the no-injection
+        // guarantee; keep it.
+        const child = spawn(cmd, args, {
+            cwd: options.cwd ?? process.cwd(),
+            env: options.env ? { ...process.env, ...options.env } : process.env,
+            stdio: ["ignore", "pipe", options.quiet ? "pipe" : "inherit"],
+        });
+
+        let stdout = "";
+        let stderr = "";
+        child.stdout?.on("data", (chunk) => {
+            stdout += chunk.toString();
+        });
+        child.stderr?.on("data", (chunk) => {
+            stderr += chunk.toString();
+        });
+
+        child.on("error", (err) => reject(err));
+        child.on("close", (code) => {
+            if (code === 0) {
+                resolve({ stdout, stderr });
+            } else {
+                reject(new ExecError(argv, code, stderr));
+            }
+        });
+    });
+}
+
+/**
+ * Run a command to completion. Resolves on exit 0, rejects (ExecError) otherwise.
+ * Mirrors `await Bun.$`cmd`` — use when you don't need the output.
+ *
+ * @param argv - command + args as a single ARGV array (NOT a shell string)
+ */
+export async function run(
+    argv: string[],
+    options: ExecOptions = {},
+): Promise<void> {
+    await spawnArgv(argv, options);
+}
+
+/**
+ * Run a command and return its stdout as a string.
+ * Mirrors `await Bun.$`cmd`.text()` / the old `Bun.spawn(...).stdout` capture.
+ *
+ * @param argv - command + args as a single ARGV array (NOT a shell string)
+ * @returns the child's stdout (not trimmed — callers trim as needed)
+ */
+export async function capture(
+    argv: string[],
+    options: ExecOptions = {},
+): Promise<string> {
+    // Capture mode always pipes both streams so output is never lost.
+    const { stdout } = await spawnArgv(argv, { ...options, quiet: true });
+    return stdout;
+}

--- a/packages/kn-next/src/cli/shared.ts
+++ b/packages/kn-next/src/cli/shared.ts
@@ -8,10 +8,35 @@
  * Adapters are no longer copied to a Nitro .output/ directory.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
+import { argv } from "node:process";
+import { fileURLToPath } from "node:url";
 import type { KnativeNextConfig } from "../config";
 import { validateConfig } from "./validate";
+
+/**
+ * Portable "is this module the entry point?" check (#68).
+ *
+ * Bun exposes `import.meta.main`; plain Node does not. Comparing the module's
+ * own file URL against the executed script path (argv[1]) works on both
+ * runtimes. realpathSync resolves symlinks (npm bin shims, .bin/ links) so the
+ * comparison holds when the CLI is launched via an installed `kn-next` bin.
+ *
+ * @param importMetaUrl - pass `import.meta.url` from the calling module
+ */
+export function isMainModule(importMetaUrl: string): boolean {
+    const entry = argv[1];
+    if (!entry) {
+        return false;
+    }
+    const modulePath = fileURLToPath(importMetaUrl);
+    try {
+        return realpathSync(modulePath) === realpathSync(entry);
+    } catch {
+        return modulePath === entry;
+    }
+}
 
 const CONFIG_FILE = "kn-next.config.ts";
 

--- a/packages/kn-next/src/utils/asset-upload.ts
+++ b/packages/kn-next/src/utils/asset-upload.ts
@@ -1,6 +1,9 @@
 import { readdirSync } from "node:fs";
 import { join, relative } from "node:path";
-import { $ } from "bun";
+// Portable shell helper (#68) — Node-native, argv-array based, runs on Node + Bun.
+// Replaces `import { $ } from "bun"`; this module is on the deploy CLI import
+// graph, so a top-level `bun` import would break `node dist/cli/deploy.js`.
+import { capture, run } from "../cli/exec";
 import type { KnativeNextConfig, StorageConfig } from "../config";
 import { createLogger } from "./logger";
 
@@ -34,6 +37,18 @@ function collectFiles(dir: string, baseDir: string): string[] {
 }
 
 /**
+ * Lists the immediate children of a directory as absolute paths.
+ *
+ * The Bun shell expanded `dir/*` via the shell glob. With an argv array there
+ * is no shell, so we expand the top-level glob here in Node and pass each entry
+ * as its own argv token — preserving the original `cp -r dir/* dest/` semantics
+ * (copy the contents of dir, not dir itself) without invoking a shell.
+ */
+function expandTopLevel(dir: string): string[] {
+    return readdirSync(dir).map((name) => join(dir, name));
+}
+
+/**
  * Uploads static assets to configured storage provider.
  * Assets include _next/static/* and public files.
  *
@@ -48,24 +63,51 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
         "Syncing assets to storage",
     );
 
+    const bucket = config.storage.bucket;
+    const cacheControl = "Cache-Control:public, max-age=31536000, immutable";
+
     switch (config.storage.provider) {
         case "gcs": {
-            // Upload with cache-control headers for immutable _next/static assets
-            await $`gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" cp -r ${assetsDir}/* gs://${config.storage.bucket}/`.quiet();
+            // Upload with cache-control headers for immutable _next/static assets.
+            // Glob expanded in Node (see expandTopLevel) — argv, no shell.
+            await run(
+                [
+                    "gsutil",
+                    "-m",
+                    "-h",
+                    cacheControl,
+                    "cp",
+                    "-r",
+                    ...expandTopLevel(assetsDir),
+                    `gs://${bucket}/`,
+                ],
+                { quiet: true },
+            );
             // Ensure bucket has public read access for browser fetches
-            await $`gsutil iam ch allUsers:objectViewer gs://${config.storage.bucket}`.quiet();
+            await run(
+                [
+                    "gsutil",
+                    "iam",
+                    "ch",
+                    "allUsers:objectViewer",
+                    `gs://${bucket}`,
+                ],
+                { quiet: true },
+            );
 
             // Post-upload verification: ensure all local files exist in GCS
             const localFiles = collectFiles(assetsDir, assetsDir);
-            const gcsListResult =
-                await $`gsutil ls -r "gs://${config.storage.bucket}/"`.text();
+            const gcsListResult = await capture([
+                "gsutil",
+                "ls",
+                "-r",
+                `gs://${bucket}/`,
+            ]);
             const gcsFiles = new Set(
                 gcsListResult
                     .split("\n")
                     .filter((line) => line.startsWith("gs://"))
-                    .map((line) =>
-                        line.replace(`gs://${config.storage.bucket}/`, ""),
-                    ),
+                    .map((line) => line.replace(`gs://${bucket}/`, "")),
             );
 
             const missing = localFiles.filter((f) => !gcsFiles.has(f));
@@ -77,8 +119,18 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
                 );
                 for (const file of missing) {
                     const localPath = join(assetsDir, file);
-                    const gcsPath = `gs://${config.storage.bucket}/${file}`;
-                    await $`gsutil -h "Cache-Control:public, max-age=31536000, immutable" cp ${localPath} ${gcsPath}`.quiet();
+                    const gcsPath = `gs://${bucket}/${file}`;
+                    await run(
+                        [
+                            "gsutil",
+                            "-h",
+                            cacheControl,
+                            "cp",
+                            localPath,
+                            gcsPath,
+                        ],
+                        { quiet: true },
+                    );
                 }
                 log.info(
                     { count: missing.length },
@@ -88,14 +140,46 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
             break;
         }
         case "s3":
-            await $`aws s3 sync ${assetsDir} s3://${config.storage.bucket} --cache-control "public, max-age=31536000, immutable"`.quiet();
+            await run(
+                [
+                    "aws",
+                    "s3",
+                    "sync",
+                    assetsDir,
+                    `s3://${bucket}`,
+                    "--cache-control",
+                    "public, max-age=31536000, immutable",
+                ],
+                { quiet: true },
+            );
             break;
         case "minio":
-            // MinIO uses S3-compatible CLI
-            await $`mc cp --recursive ${assetsDir}/* minio/${config.storage.bucket}/`.quiet();
+            // MinIO uses S3-compatible CLI. Glob expanded in Node — argv, no shell.
+            await run(
+                [
+                    "mc",
+                    "cp",
+                    "--recursive",
+                    ...expandTopLevel(assetsDir),
+                    `minio/${bucket}/`,
+                ],
+                { quiet: true },
+            );
             break;
         case "azure":
-            await $`az storage blob upload-batch -d ${config.storage.bucket} -s ${assetsDir}`.quiet();
+            await run(
+                [
+                    "az",
+                    "storage",
+                    "blob",
+                    "upload-batch",
+                    "-d",
+                    bucket,
+                    "-s",
+                    assetsDir,
+                ],
+                { quiet: true },
+            );
             break;
         default:
             throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       bun-types:
         specifier: ^1.3.9
         version: 1.3.9
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@4.0.18)(happy-dom@20.5.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.2)


### PR DESCRIPTION
Closes #68

## What
Ports the `kn-next` CLI off Bun-only so `npx kn-next` works on plain Node, without dropping Bun support.

- New `cli/exec.ts` — portable `run()`/`capture()` over `node:child_process.spawn` with `shell:false` + argv arrays (injection-proof). Replaces `import { $ } from 'bun'` / `Bun.spawn`.
- Node shebangs; `isMainModule()` replaces `import.meta.main`.
- Real build step (`scripts/build-cli.mjs`, esbuild) emits `dist/cli/*.js`; `bin.kn-next` → `dist/cli/deploy.js` (was raw `.ts`). `engines.node>=20`.
- CI: new `cli-node-smoke` job (Node leg installs no Bun; both legs assert `deploy --dry-run` prints a NextApp CR).

## Tests
- Canonical `vitest run`: **76/76 pass** (13 new for #68).
- Node-only verified: with Bun off PATH, `node dist/cli/deploy.js deploy --dry-run` emits a valid NextApp CR.
- Note: 3 pre-existing `vi.resetModules` failures under `bun test` live in #64's `cache-handler-keyprefix.test.ts` (untouched here) — out of scope for #68.

🤖 Drafted by the knext-ship pipeline; pending code + spec review and architect / system-designer sign-off.