### PR TITLE
feat: persist optimized image variants across scale-to-zero (ADR-0006)

### DIFF
--- a/docs/adr/0006-image-optimization.md
+++ b/docs/adr/0006-image-optimization.md
@@ -27,11 +27,12 @@ variants in the object store (GCS/S3) so they survive scale-to-zero — not pod-
 
 1. Add `sharp` to the runtime image (distroless Node) so `/_next/image` works natively. No new
    service, no API surface — `next/image` "just works".
-2. Back the optimized-image cache with the **object store** via the adapter's image cache handler
-   (mirrors how the ISR/data cache is Redis-backed): first request optimizes + writes the variant to
-   the store keyed by `(src, w, q, accept)`; later requests (any pod) read the cached variant. This
-   is the knext-native analogue of the reference Bun adapter's `SqliteImageCacheStore` (we use the
-   object store instead of SQLite — see `docs/research/adapter-bun-learnings.md`).
+2. Back the optimized-image cache with the **object store** so variants survive scale-to-zero:
+   first request optimizes + persists the variant to the store keyed by `(src, w, q, accept)`;
+   later requests (any pod) reuse the persisted variant. This is the knext-native analogue of the
+   reference Bun adapter's `SqliteImageCacheStore` (we use the object store instead of SQLite — see
+   `docs/research/adapter-bun-learnings.md`). **See the Correction below for the actual integration
+   mechanism** (a directory sync on the pinned Next 16.0.3, not a pluggable hook).
 3. Configure `images.formats` (AVIF/WebP), `deviceSizes`/`imageSizes`, and a strict
    `remotePatterns` allowlist (no open SSRF proxy).
 
@@ -53,11 +54,48 @@ variants in the object store (GCS/S3) so they survive scale-to-zero — not pod-
   vector (cf. the `POST /api/cache/invalidate` lesson; never an open mutating/proxy endpoint).
 - **Supply chain:** `sharp` is a native dep → must be in the SBOM/Trivy scan (Tier B / B2).
 
+## Correction (2026-06-22, issue #66) — the integration mechanism
+
+ADR item 2 originally assumed knext could register the image cache the way it registers the ISR
+cache (a pluggable handler). **Verification against the pinned runtime found that is false for
+Next 16.0.3**, the version knext ships:
+
+- The ISR/data cache **is** pluggable via `next.config.cacheHandler` (knext's Redis handler).
+- The **image** optimizer cache is **not** pluggable in 16.0.3: `next/dist/server/next-server.js`
+  hardcodes `const { ImageOptimizerCache } = require('./image-optimizer')` and instantiates it
+  directly, writing variants to a **pod-local** `<distDir>/cache/images/<cacheKey>/…`. IMAGE-kind
+  entries are routed through a dedicated `imageResponseCache` with `incrementalCache:
+  imageOptimizerCache`, **never** through `next.config.cacheHandler`. There is no `images.cacheHandler`
+  option and `maximumDiskCacheSize` does not yet exist.
+- **Next 16.2+ did add the hook** the ADR assumed: the docs for `maximumDiskCacheSize` now state you
+  may "implement your own cache handler using `cacheHandler`" for images. So once knext upgrades to
+  ≥16.2 this can become an object-store `cacheHandler` that handles `CachedRouteKind.IMAGE` — the
+  cleaner end state.
+
+**Caveats of the directory-sync mechanism (acceptable):** (1) the on-disk cache only exists when
+`isrFlushToDisk` is true (Next's default) — an app that disables it writes nothing to disk, so the
+sync silently no-ops. (2) A variant served before its debounced push completes makes the next cold
+pod re-optimize it exactly once (then it persists) — idempotent, no data loss. Both disappear under
+the ≥16.2 `cacheHandler` end state.
+
+**Chosen mechanism on the pinned version (no API faking, no interception):** a **directory sync** of
+the dir Next already writes. Next's on-disk `cacheKey` is
+`hash([CACHE_VERSION, href, width, quality, mimeType])` — i.e. exactly the `(src, w, q, accept)` key
+this ADR requires — so the per-variant directory name *is* the content-addressed key. On startup the
+runtime **restores** persisted variants from the object store into `.next/cache/images` (warm cache);
+while running it **watches** that dir and **pushes** newly-written variants up. Implemented in
+`packages/kn-next/src/adapters/image-cache-sync.ts`, wired into the runtime entry
+`packages/kn-next/src/adapters/node-server.ts`, guarded by `STORAGE_BUCKET` (no-op → pod-local
+fallback when unset). The chosen-option name above remains "Next built-in `sharp` + object-store
+variant cache"; only the *binding* is a sync rather than a hook on this version.
+
 ## Action items (→ A4-2)
 
-1. Add `sharp` to `apps/file-manager/Dockerfile` runtime stage; verify `/_next/image` returns
-   resized/format-negotiated output (compat-suite image cases).
-2. Implement the object-store image cache handler (`(src,w,q,accept)` key) in the adapter; wire via
-   `images.loader`/cache config.
-3. Set `images.formats`, sizes, and a strict `remotePatterns` allowlist in the app config.
+1. [done #43] Add `sharp` to `apps/file-manager/Dockerfile` runtime stage; verify `/_next/image`
+   returns resized/format-negotiated output (compat-suite image cases).
+2. [done #66] Persist optimized variants in the object store, keyed by `(src,w,q,accept)`, so they
+   survive scale-to-zero — via the directory sync described in the Correction (pinned 16.0.3 has no
+   pluggable image cache hook). Replace with a `cacheHandler`-based IMAGE handler after upgrading to
+   Next ≥ 16.2.
+3. [done #43] Set `images.formats`, sizes, and a strict `remotePatterns` allowlist in the app config.
 4. Gate on the official compatibility suite image cases (A3).

--- a/packages/kn-next/src/__tests__/image-cache-sync.test.ts
+++ b/packages/kn-next/src/__tests__/image-cache-sync.test.ts
@@ -1,0 +1,169 @@
+import { existsSync, promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    type ImageVariantStore,
+    pushVariant,
+    restoreImageCache,
+    startImageCacheSync,
+} from "../adapters/image-cache-sync";
+
+/**
+ * Verifies ADR-0006 item 2: optimized image variants survive scale-to-zero by
+ * persisting in the object store, keyed by Next's per-variant cacheKey dir name
+ * (= (src,w,q,accept)). Uses an in-memory fake store + a real temp cache dir, so
+ * no live MinIO/network is required (mirrors the cache-handler test discipline).
+ */
+
+const SILENT = { info: () => {}, warn: () => {} };
+
+/** In-memory ImageVariantStore: bucket → key → file bytes. */
+function fakeStore(seed: Record<string, Buffer> = {}): ImageVariantStore & {
+    objects: Map<string, Buffer>;
+} {
+    const objects = new Map<string, Buffer>(Object.entries(seed));
+    return {
+        objects,
+        async list(_bucket, prefix) {
+            return [...objects.keys()].filter((k) => k.startsWith(prefix));
+        },
+        async download(_bucket, key, destPath) {
+            const data = objects.get(key);
+            if (!data) throw new Error(`no such object: ${key}`);
+            await fs.mkdir(join(destPath, ".."), { recursive: true });
+            await fs.writeFile(destPath, data);
+        },
+        async upload(_bucket, key, srcPath) {
+            objects.set(key, await fs.readFile(srcPath));
+        },
+    };
+}
+
+describe("image-cache-sync", () => {
+    let cacheDir: string;
+
+    beforeEach(async () => {
+        cacheDir = await fs.mkdtemp(join(tmpdir(), "knext-imgcache-"));
+    });
+
+    afterEach(async () => {
+        await fs.rm(cacheDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it("restores persisted variants into the local cache dir, keyed by cacheKey", async () => {
+        // Store holds one variant `abc123` with one file (Next's filename layout).
+        const variantFile = "31536000.1700000000.etag.upstream.webp";
+        const store = fakeStore({
+            [`image-cache/abc123/${variantFile}`]: Buffer.from("AVIF-BYTES"),
+        });
+
+        const restored = await restoreImageCache({
+            bucket: "b",
+            cacheDir,
+            store,
+            log: SILENT,
+        });
+
+        expect(restored).toBe(1);
+        const local = join(cacheDir, "abc123", variantFile);
+        expect(existsSync(local)).toBe(true);
+        expect(await fs.readFile(local, "utf8")).toBe("AVIF-BYTES");
+    });
+
+    it("skips restoring files that already exist locally (no clobber)", async () => {
+        const variantFile = "1.2.e.u.webp";
+        const local = join(cacheDir, "key1", variantFile);
+        await fs.mkdir(join(cacheDir, "key1"), { recursive: true });
+        await fs.writeFile(local, "LOCAL-NEWER");
+
+        const store = fakeStore({
+            [`image-cache/key1/${variantFile}`]: Buffer.from("STORE-OLD"),
+        });
+        const download = vi.spyOn(store, "download");
+
+        const restored = await restoreImageCache({
+            bucket: "b",
+            cacheDir,
+            store,
+            log: SILENT,
+        });
+
+        expect(restored).toBe(0);
+        expect(download).not.toHaveBeenCalled();
+        expect(await fs.readFile(local, "utf8")).toBe("LOCAL-NEWER");
+    });
+
+    it("pushes a newly-written variant directory to the store under <prefix>/<cacheKey>/<file>", async () => {
+        const store = fakeStore();
+        const variantDir = join(cacheDir, "deadbeef");
+        await fs.mkdir(variantDir, { recursive: true });
+        await fs.writeFile(join(variantDir, "1.2.e.u.avif"), "OPTIMIZED");
+
+        const uploaded = await pushVariant("deadbeef", {
+            bucket: "b",
+            cacheDir,
+            store,
+            log: SILENT,
+        });
+
+        expect(uploaded).toBe(1);
+        expect(
+            store.objects.get("image-cache/deadbeef/1.2.e.u.avif")?.toString(),
+        ).toBe("OPTIMIZED");
+    });
+
+    it("round-trips: a variant pushed by 'pod A' is restored by 'pod B' (scale-to-zero survival)", async () => {
+        const store = fakeStore();
+
+        // Pod A optimizes + writes a variant locally, then pushes it.
+        const podA = join(cacheDir, "podA");
+        const variantDir = join(podA, "v1key");
+        await fs.mkdir(variantDir, { recursive: true });
+        await fs.writeFile(join(variantDir, "x.webp"), "VARIANT");
+        await pushVariant("v1key", {
+            bucket: "b",
+            cacheDir: podA,
+            store,
+            log: SILENT,
+        });
+
+        // Pod B starts cold (empty dir) and restores from the store.
+        const podB = join(cacheDir, "podB");
+        const restored = await restoreImageCache({
+            bucket: "b",
+            cacheDir: podB,
+            store,
+            log: SILENT,
+        });
+
+        expect(restored).toBe(1);
+        expect(await fs.readFile(join(podB, "v1key", "x.webp"), "utf8")).toBe(
+            "VARIANT",
+        );
+    });
+
+    it("is a no-op when STORAGE_BUCKET is unset", async () => {
+        const store = fakeStore();
+        const list = vi.spyOn(store, "list");
+
+        const handle = await startImageCacheSync(
+            { IMAGE_CACHE_DIR: cacheDir }, // no STORAGE_BUCKET
+            { store, log: SILENT },
+        );
+
+        expect(list).not.toHaveBeenCalled();
+        expect(typeof handle.stop).toBe("function");
+        handle.stop(); // safe no-op
+    });
+
+    it("degrades gracefully: a store list failure does not throw", async () => {
+        const store = fakeStore();
+        vi.spyOn(store, "list").mockRejectedValue(new Error("store down"));
+
+        await expect(
+            restoreImageCache({ bucket: "b", cacheDir, store, log: SILENT }),
+        ).resolves.toBe(0);
+    });
+});

--- a/packages/kn-next/src/adapters/image-cache-sync.ts
+++ b/packages/kn-next/src/adapters/image-cache-sync.ts
@@ -1,0 +1,327 @@
+/**
+ * Object-store sync for Next.js optimized-image variants — survives scale-to-zero.
+ *
+ * ── Why this exists (ADR-0006, item 2) ───────────────────────────────────────
+ * `next/image` runtime optimization (the `/_next/image` endpoint) writes optimized
+ * variants (resized + format-negotiated WebP/AVIF) to a POD-LOCAL directory:
+ *   `<distDir>/cache/images/<cacheKey>/<maxAge>.<expireAt>.<etag>.<upstreamEtag>.<ext>`
+ * where, in Next.js, `cacheKey = hash([CACHE_VERSION, href, width, quality, mimeType])`
+ * (see next/dist/server/image-optimizer.js → `ImageOptimizerCache.getCacheKey`).
+ * That hash IS the `(src, w, q, accept)` key ADR-0006 requires: href=src, width=w,
+ * quality=q, mimeType=the negotiated Accept format. So the on-disk directory name is
+ * already the content-addressed variant key — we do not need to recompute it.
+ *
+ * Under Knative scale-to-zero, every cold pod starts with an empty local cache dir,
+ * so it re-optimizes images another pod already produced — wasting the cold-start
+ * CPU budget. This module persists the per-variant directories in the object store
+ * (GCS/S3/MinIO — knext's data plane) so a variant computed by one pod is reused by
+ * every later pod.
+ *
+ * ── Why a sync (and not a pluggable cache handler) ───────────────────────────
+ * Next.js exposes a pluggable ISR/data cache via `next.config.cacheHandler`, but in
+ * the pinned runtime (Next 16.0.3) the IMAGE optimizer cache is NOT pluggable: the
+ * server hardcodes `new ImageOptimizerCache(...)` writing to `<distDir>/cache/images`
+ * and does not route IMAGE-kind entries through `cacheHandler`. (Next 16.2+ DID make
+ * the image disk cache overridable via the same `cacheHandler` option — see
+ * ADR-0006 "Correction" note. When knext upgrades, this sync can be replaced by an
+ * object-store cacheHandler that handles `CachedRouteKind.IMAGE`.)
+ *
+ * So on the pinned version we use the only real, non-interception integration point:
+ * sync the directory Next already writes. On startup we RESTORE existing variants
+ * from the store into the local dir (warm the cache); while running we WATCH the dir
+ * and PUSH newly-written variants up. Both directions are keyed by the per-variant
+ * cacheKey directory name = `(src,w,q,accept)`.
+ *
+ * Guarded by `STORAGE_BUCKET` (same guard as the adapter's build-artifact upload):
+ * when unset, this is a no-op and Next falls back to pod-local caching.
+ */
+
+import { existsSync, promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Minimal object-store surface this module needs. Mirrors the MinIO client used by
+ * `next-adapter.ts` (`getMinioClient()`), but is narrowed to an interface so unit
+ * tests can inject a fake without a live store / network.
+ */
+export interface ImageVariantStore {
+    /** List object keys under a prefix. */
+    list(bucket: string, prefix: string): Promise<string[]>;
+    /** Download an object to a local file path. */
+    download(bucket: string, key: string, destPath: string): Promise<void>;
+    /** Upload a local file to an object key. */
+    upload(bucket: string, key: string, srcPath: string): Promise<void>;
+}
+
+export interface ImageCacheSyncOptions {
+    /** Object-store bucket. From STORAGE_BUCKET. */
+    bucket: string;
+    /**
+     * Local optimized-image cache dir Next writes to. Default mirrors Next:
+     * `<cwd>/.next/cache/images`. Standalone output keeps the same relative layout.
+     */
+    cacheDir?: string;
+    /**
+     * Key prefix in the bucket. Namespaces image variants away from build artifacts
+     * + ISR keys. Default `image-cache`. (The deploy path sets per-app buckets, so a
+     * static prefix is safe; callers may override per app if sharing a bucket.)
+     */
+    prefix?: string;
+    /** Injected store. Defaults to the MinIO-backed adapter at runtime. */
+    store?: ImageVariantStore;
+    /** Logger (defaults to console). `console` and the pino runtime logger both satisfy it. */
+    log?: SyncLogger;
+}
+
+/**
+ * Minimal logger surface satisfied by both `console` and the kn-next pino logger
+ * (which exposes `info`/`warn` but not `log`). Single-string calls only.
+ */
+export interface SyncLogger {
+    info(msg: string): void;
+    warn(msg: string): void;
+}
+
+const DEFAULT_PREFIX = "image-cache";
+
+function defaultCacheDir(): string {
+    return join(process.cwd(), ".next", "cache", "images");
+}
+
+/** Build the object key for a local cache file: `<prefix>/<cacheKey>/<file>`. */
+function objectKey(prefix: string, cacheKey: string, file: string): string {
+    return `${prefix}/${cacheKey}/${file}`;
+}
+
+/**
+ * Lazily build a MinIO-backed {@link ImageVariantStore} from `@knext/lib`'s client,
+ * matching how `next-adapter.ts` resolves its uploader. Imported dynamically so the
+ * dependency never loads when STORAGE_BUCKET is unset (or in tests that inject a fake).
+ */
+async function defaultStore(): Promise<ImageVariantStore | null> {
+    try {
+        const { getMinioClient } = await import("@knext/lib/clients");
+        const client = getMinioClient();
+        return {
+            async list(bucket, prefix) {
+                const keys: string[] = [];
+                const stream = client.listObjectsV2(bucket, prefix, true);
+                await new Promise<void>((resolvePromise, reject) => {
+                    stream.on("data", (obj: { name?: string }) => {
+                        if (obj.name) keys.push(obj.name);
+                    });
+                    stream.on("end", () => resolvePromise());
+                    stream.on("error", reject);
+                });
+                return keys;
+            },
+            async download(bucket, key, destPath) {
+                await fs.mkdir(dirname(destPath), { recursive: true });
+                await client.fGetObject(bucket, key, destPath);
+            },
+            async upload(bucket, key, srcPath) {
+                await client.fPutObject(bucket, key, srcPath, {});
+            },
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * RESTORE: download every persisted variant from the store into the local cache dir,
+ * skipping files that already exist locally. Best-effort — failures are logged, never
+ * thrown, so a store outage degrades to local-only optimization rather than a crash.
+ *
+ * @returns number of variant files restored.
+ */
+export async function restoreImageCache(
+    opts: ImageCacheSyncOptions,
+): Promise<number> {
+    const log = opts.log ?? console;
+    const prefix = opts.prefix ?? DEFAULT_PREFIX;
+    const cacheDir = opts.cacheDir ?? defaultCacheDir();
+    const store = opts.store ?? (await defaultStore());
+
+    if (!store) {
+        log.warn(
+            "[image-cache-sync] restore skipped: object store client unavailable",
+        );
+        return 0;
+    }
+
+    let restored = 0;
+    try {
+        const keys = await store.list(opts.bucket, `${prefix}/`);
+        for (const key of keys) {
+            // key = `<prefix>/<cacheKey>/<file>` → local `<cacheDir>/<cacheKey>/<file>`
+            const rel = key.slice(prefix.length + 1); // strip `<prefix>/`
+            if (!rel) continue;
+            const destPath = join(cacheDir, rel);
+            if (existsSync(destPath)) continue;
+            try {
+                await store.download(opts.bucket, key, destPath);
+                restored++;
+            } catch (err) {
+                log.warn(
+                    `[image-cache-sync] restore warning: failed "${key}" — ${String(err)}`,
+                );
+            }
+        }
+    } catch (err) {
+        log.warn(
+            `[image-cache-sync] restore skipped: could not list store — ${String(err)}`,
+        );
+        return restored;
+    }
+
+    log.info(
+        `[image-cache-sync] restore complete: ${restored} variant file(s) warmed into ${cacheDir}`,
+    );
+    return restored;
+}
+
+/**
+ * PUSH a single variant directory (one cacheKey = one `(src,w,q,accept)` variant) to
+ * the store. Uploads every file in the directory under `<prefix>/<cacheKey>/<file>`.
+ * Idempotent: re-uploading an identical variant overwrites with the same bytes.
+ */
+export async function pushVariant(
+    cacheKey: string,
+    opts: ImageCacheSyncOptions & { store: ImageVariantStore },
+): Promise<number> {
+    const log = opts.log ?? console;
+    const prefix = opts.prefix ?? DEFAULT_PREFIX;
+    const cacheDir = opts.cacheDir ?? defaultCacheDir();
+    const variantDir = join(cacheDir, cacheKey);
+
+    let files: string[];
+    try {
+        files = await fs.readdir(variantDir);
+    } catch {
+        return 0; // directory vanished (e.g. LRU eviction) — nothing to push
+    }
+
+    let uploaded = 0;
+    for (const file of files) {
+        try {
+            await opts.store.upload(
+                opts.bucket,
+                objectKey(prefix, cacheKey, file),
+                join(variantDir, file),
+            );
+            uploaded++;
+        } catch (err) {
+            log.warn(
+                `[image-cache-sync] push warning: failed "${cacheKey}/${file}" — ${String(err)}`,
+            );
+        }
+    }
+    if (uploaded > 0) {
+        log.info(
+            `[image-cache-sync] pushed variant ${cacheKey} (${uploaded} file(s)) to store`,
+        );
+    }
+    return uploaded;
+}
+
+/**
+ * WATCH the local image cache dir; when Next writes a new variant directory, push it
+ * to the store. Returns a stop() handle. Uses `fs.watch` (recursive) — best-effort and
+ * debounced so the multi-file write of one variant becomes one upload pass.
+ *
+ * Note: `fs.watch({recursive:true})` is supported on Linux (Node ≥ 20) and macOS,
+ * which covers the distroless runtime and local dev. If watching is unavailable the
+ * caller still benefits from the startup restore; we log and return a no-op stop.
+ */
+export async function watchAndPushImageCache(
+    opts: ImageCacheSyncOptions,
+): Promise<{ stop: () => void }> {
+    const log = opts.log ?? console;
+    const cacheDir = opts.cacheDir ?? defaultCacheDir();
+    const store = opts.store ?? (await defaultStore());
+    const noop = { stop: () => {} };
+
+    if (!store) {
+        log.warn(
+            "[image-cache-sync] watch skipped: object store client unavailable",
+        );
+        return noop;
+    }
+
+    await fs.mkdir(cacheDir, { recursive: true });
+
+    const pending = new Set<string>();
+    let timer: NodeJS.Timeout | null = null;
+    const FLUSH_MS = 500;
+
+    const flush = () => {
+        timer = null;
+        const keys = [...pending];
+        pending.clear();
+        for (const cacheKey of keys) {
+            void pushVariant(cacheKey, { ...opts, store });
+        }
+    };
+
+    let watcher: import("node:fs").FSWatcher;
+    try {
+        const { watch } = await import("node:fs");
+        watcher = watch(cacheDir, { recursive: true }, (_event, filename) => {
+            if (!filename) return;
+            // filename is `<cacheKey>/<file>` (or just `<cacheKey>`); take the first segment.
+            const cacheKey = String(filename).split(/[/\\]/)[0];
+            if (!cacheKey) return;
+            pending.add(cacheKey);
+            if (!timer) timer = setTimeout(flush, FLUSH_MS);
+        });
+    } catch (err) {
+        log.warn(
+            `[image-cache-sync] watch unavailable (restore-only mode) — ${String(err)}`,
+        );
+        return noop;
+    }
+
+    log.info(
+        `[image-cache-sync] watching ${cacheDir} for new optimized variants`,
+    );
+    return {
+        stop: () => {
+            if (timer) clearTimeout(timer);
+            watcher.close();
+        },
+    };
+}
+
+/**
+ * Top-level entry: restore-then-watch. Guarded by STORAGE_BUCKET. Returns a stop()
+ * handle (no-op when disabled). Call once from the runtime entry, before/around the
+ * Next standalone server starts.
+ */
+export async function startImageCacheSync(
+    env: NodeJS.ProcessEnv = process.env,
+    deps: {
+        log?: SyncLogger;
+        store?: ImageVariantStore;
+    } = {},
+): Promise<{ stop: () => void }> {
+    const log = deps.log ?? console;
+    const bucket = env.STORAGE_BUCKET;
+    if (!bucket) {
+        log.info(
+            "[image-cache-sync] disabled: STORAGE_BUCKET not set — image variants stay pod-local",
+        );
+        return { stop: () => {} };
+    }
+
+    const opts: ImageCacheSyncOptions = {
+        bucket,
+        prefix: env.IMAGE_CACHE_PREFIX || DEFAULT_PREFIX,
+        cacheDir: env.IMAGE_CACHE_DIR || undefined,
+        store: deps.store,
+        log,
+    };
+
+    await restoreImageCache(opts);
+    return watchAndPushImageCache(opts);
+}

--- a/packages/kn-next/src/adapters/node-server.ts
+++ b/packages/kn-next/src/adapters/node-server.ts
@@ -16,10 +16,11 @@
 
 import { spawn } from "node:child_process";
 import http from "node:http";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { collectDefaultMetrics, Registry } from "prom-client";
 import { createLogger } from "../utils/logger";
 import { buildChildEnv } from "./env";
+import { startImageCacheSync } from "./image-cache-sync";
 import { gracefulShutdown } from "./shutdown";
 
 const log = createLogger({ module: "server" });
@@ -58,6 +59,26 @@ const serverJs = resolve(
 
 log.info({ serverJs }, "Starting Next.js standalone server");
 
+// ── Optimized-image variant cache sync (ADR-0006) ─────────────────────────────
+// next/image writes optimized variants to `<distDir>/cache/images`, which is
+// pod-local — so every cold pod re-optimizes images another pod already produced,
+// burning the scale-to-zero cold-start budget. Persist those variants in the
+// object store (keyed by Next's per-variant cacheKey = (src,w,q,accept)) so a
+// variant computed once is reused by every later pod. No-op unless STORAGE_BUCKET
+// is set. The standalone server keeps `.next/cache/images` next to server.js, so
+// derive the dir from the server path (override via IMAGE_CACHE_DIR if needed).
+const imageCacheDir =
+    process.env.IMAGE_CACHE_DIR ??
+    resolve(dirname(serverJs), ".next", "cache", "images");
+let stopImageCacheSync: () => void = () => {};
+startImageCacheSync({ ...process.env, IMAGE_CACHE_DIR: imageCacheDir }, { log })
+    .then((handle) => {
+        stopImageCacheSync = handle.stop;
+    })
+    .catch((err) => {
+        log.warn({ err }, "Image cache sync failed to start (non-fatal)");
+    });
+
 const nextProc = spawn(process.execPath, [serverJs], {
     stdio: "inherit",
     env: buildChildEnv(),
@@ -83,6 +104,7 @@ const onSignal = (signal: string) => {
         { signal, graceMs: SHUTDOWN_GRACE_MS },
         "Shutting down gracefully...",
     );
+    stopImageCacheSync();
     gracefulShutdown(signal, {
         child: nextProc,
         closables: [metricsServer],


### PR DESCRIPTION
Closes #66.

Finishes ADR-0006: `next/image` optimization worked, but variants were **pod-local** (`.next/cache/images`), so every cold pod re-optimized from source.

**Research finding (honest):** the pinned **Next 16.0.3 has no pluggable image cacheHandler** (only ≥16.2 does) — ADR-0006 item-2 corrected in the ADR. So instead of faking a Next API, this uses an **object-store directory sync**. Next's on-disk `cacheKey` already hashes `[CACHE_VERSION, href, width, quality, mimeType]` = exactly `(src,w,q,accept)`, so `image-cache-sync.ts` **restores** persisted variants on startup and **watches+pushes** new ones to the object store (reuses the `@knext/lib` minio client; guarded by `STORAGE_BUCKET`; pod-local fallback when unset).

Wired into `node-server.ts`: fully **best-effort** (store outage degrades, never crashes the runtime), stopped on SIGTERM/SIGINT before graceful shutdown. 6 tests incl. a pod-A-push → pod-B-restore round-trip.

Independent review APPROVE (verified vs installed Next 16.0.3 source: spec sound, runtime-safe, no path traversal). typecheck + 69 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)