### PR TITLE
CLI: extend asset-upload verification to S3/MinIO/Azure + data-plane tests (#75)

### DIFF
--- a/packages/kn-next/src/__tests__/asset-upload.test.ts
+++ b/packages/kn-next/src/__tests__/asset-upload.test.ts
@@ -1,0 +1,233 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+/**
+ * Data-plane tests for asset upload + post-upload verification (#75).
+ *
+ * The provider CLIs (`gsutil`/`aws`/`mc`/`az`) are never spawned: the `exec`
+ * layer (`runQuiet`/`runCapture`) is mocked, so these tests assert the CONTRACT
+ * — which binary is invoked with which argv, that verification lists the remote
+ * prefix and diffs it against the local file set, that a missing object fails
+ * the deploy loudly (non-zero / throw) naming the offending keys, and that argv
+ * is injection-safe (discrete array elements, never a shell string).
+ *
+ * No live cloud credentials are required (CLAUDE.md §9: GCS + an S3-compatible
+ * store are the two real data planes; the rest are thin shell-outs).
+ */
+
+vi.mock("../cli/exec", () => ({
+    runQuiet: vi.fn(),
+    runCapture: vi.fn(),
+}));
+
+import { runCapture, runQuiet } from "../cli/exec";
+import type { KnativeNextConfig, StorageProvider } from "../config";
+import { uploadAssets } from "../utils/asset-upload";
+
+const runQuietMock = runQuiet as unknown as Mock;
+const runCaptureMock = runCapture as unknown as Mock;
+
+/** Builds a minimal config for a given provider + bucket. */
+function makeConfig(
+    provider: StorageProvider,
+    bucket: string,
+): KnativeNextConfig {
+    return {
+        storage: {
+            provider,
+            bucket,
+            publicUrl: `https://example.test/${bucket}`,
+        },
+    } as unknown as KnativeNextConfig;
+}
+
+/**
+ * How each provider renders a remote listing for the mocked `runCapture`,
+ * given the set of keys the fake remote "contains". Mirrors the real CLI
+ * `ls`-style output that the verification pass parses.
+ */
+const REMOTE_LISTERS: Record<
+    StorageProvider,
+    (bucket: string, keys: string[]) => string
+> = {
+    gcs: (bucket, keys) => keys.map((k) => `gs://${bucket}/${k}`).join("\n"),
+    s3: (_bucket, keys) => keys.join("\n"),
+    minio: (bucket, keys) => keys.map((k) => `minio/${bucket}/${k}`).join("\n"),
+    // `az storage blob list --query [].name -o json` → flat array of names.
+    azure: (_bucket, keys) => JSON.stringify(keys),
+};
+
+describe("uploadAssets data plane", () => {
+    let assetsDir: string;
+    let prevCwd: string;
+    const localKeys = [
+        "_next/static/chunks/main.js",
+        "_next/static/css/app.css",
+        "favicon.ico",
+    ];
+
+    beforeEach(async () => {
+        prevCwd = process.cwd();
+        const root = await fs.mkdtemp(join(tmpdir(), "knext-assets-"));
+        assetsDir = join(root, ".output", "public");
+        // Write the local file set under .output/public/<key>.
+        for (const key of localKeys) {
+            const full = join(assetsDir, key);
+            await fs.mkdir(join(full, ".."), { recursive: true });
+            await fs.writeFile(full, `bytes:${key}`);
+        }
+        process.chdir(root);
+        runQuietMock.mockReset();
+        runCaptureMock.mockReset();
+    });
+
+    afterEach(async () => {
+        process.chdir(prevCwd);
+        vi.clearAllMocks();
+    });
+
+    /** All argv arrays passed to either exec helper, for argv-shape assertions. */
+    function allArgvs(): string[][] {
+        return [
+            ...runQuietMock.mock.calls.map((c) => c[0] as string[]),
+            ...runCaptureMock.mock.calls.map((c) => c[0] as string[]),
+        ];
+    }
+
+    const providers: StorageProvider[] = ["gcs", "s3", "minio", "azure"];
+
+    describe.each(providers)("provider=%s", (provider) => {
+        const bucket = "my-bucket";
+
+        it("success path: bulk-uploads then verifies, no re-upload when complete", async () => {
+            // Remote contains every local key → verification finds nothing missing.
+            runCaptureMock.mockReturnValue(
+                REMOTE_LISTERS[provider](bucket, localKeys),
+            );
+
+            await expect(
+                uploadAssets(makeConfig(provider, bucket)),
+            ).resolves.toBeUndefined();
+
+            // Verification listed the remote (runCapture invoked at least once).
+            expect(runCaptureMock).toHaveBeenCalled();
+
+            // No per-file retry upload happened: the bulk upload is the only
+            // upload, so no argv equals the single-file re-upload of a key.
+            const argvs = allArgvs();
+            const retried = argvs.some((argv) =>
+                localKeys.some(
+                    (k) =>
+                        argv.includes(join(assetsDir, k)) &&
+                        // a single-file retry references exactly one local path
+                        argv.filter((a) => a.startsWith(assetsDir)).length ===
+                            1,
+                ),
+            );
+            expect(retried).toBe(false);
+        });
+
+        it("partial failure: re-uploads the missing key then fails loudly if still missing", async () => {
+            const missingKey = localKeys[1];
+            const presentKeys = localKeys.filter((k) => k !== missingKey);
+            // Remote NEVER has the missing key, even after a retry upload →
+            // verification must fail the deploy and name the offending key.
+            runCaptureMock.mockReturnValue(
+                REMOTE_LISTERS[provider](bucket, presentKeys),
+            );
+
+            await expect(
+                uploadAssets(makeConfig(provider, bucket)),
+            ).rejects.toThrow(missingKey);
+        });
+
+        it("verification catches a missing object even with a clean bulk upload", async () => {
+            // Bulk upload command "succeeds" (runQuiet does not throw), but the
+            // remote listing is missing one object → must throw.
+            runCaptureMock.mockReturnValue(
+                REMOTE_LISTERS[provider](
+                    bucket,
+                    localKeys.slice(0, localKeys.length - 1),
+                ),
+            );
+
+            await expect(
+                uploadAssets(makeConfig(provider, bucket)),
+            ).rejects.toThrow();
+        });
+
+        it("argv is injection-safe: array tokens, no shell metachars concatenated", async () => {
+            runCaptureMock.mockReturnValue(
+                REMOTE_LISTERS[provider](bucket, localKeys),
+            );
+            await uploadAssets(makeConfig(provider, bucket));
+
+            const argvs = allArgvs();
+            expect(argvs.length).toBeGreaterThan(0);
+            for (const argv of argvs) {
+                // Every argv element is a string and the binary is a bare name
+                // (no shell pipe / redirect / chaining smuggled into argv[0]).
+                expect(Array.isArray(argv)).toBe(true);
+                expect(typeof argv[0]).toBe("string");
+                expect(argv[0]).not.toMatch(/[;&|`$()<>]/);
+            }
+        });
+    });
+
+    it("uses the correct provider CLI binary per provider", async () => {
+        const expected: Record<StorageProvider, string> = {
+            gcs: "gsutil",
+            s3: "aws",
+            minio: "mc",
+            azure: "az",
+        };
+        for (const provider of providers) {
+            runQuietMock.mockReset();
+            runCaptureMock.mockReset();
+            runCaptureMock.mockReturnValue(
+                REMOTE_LISTERS[provider]("b", localKeys),
+            );
+            await uploadAssets(makeConfig(provider, "b"));
+            const bins = [
+                ...runQuietMock.mock.calls.map((c) => (c[0] as string[])[0]),
+                ...runCaptureMock.mock.calls.map((c) => (c[0] as string[])[0]),
+            ];
+            expect(bins).toContain(expected[provider]);
+        }
+    });
+
+    it("re-upload failure surfaces the key + underlying error", async () => {
+        const missingKey = localKeys[0];
+        // Remote is missing the key; the per-file retry upload itself throws —
+        // the error must name the key so the operator can see what broke.
+        runCaptureMock.mockReturnValue(
+            REMOTE_LISTERS.s3(
+                "b",
+                localKeys.filter((k) => k !== missingKey),
+            ),
+        );
+        runQuietMock.mockImplementation((argv: string[]) => {
+            // Bulk upload (the `sync`) is fine; only the single-file retry that
+            // references the missing key throws.
+            if (
+                argv.includes(join(assetsDir, missingKey)) &&
+                argv.filter((a) => a.startsWith(assetsDir)).length === 1
+            ) {
+                throw new Error("AccessDenied uploading object");
+            }
+        });
+        await expect(uploadAssets(makeConfig("s3", "b"))).rejects.toThrow(
+            missingKey,
+        );
+    });
+});

--- a/packages/kn-next/src/utils/asset-upload.ts
+++ b/packages/kn-next/src/utils/asset-upload.ts
@@ -43,11 +43,333 @@ function collectFiles(dir: string, baseDir: string): string[] {
 }
 
 /**
- * Uploads static assets to configured storage provider.
- * Assets include _next/static/* and public files.
- *
- * For GCS: also sets public read access, cache-control headers,
- * and verifies all files were uploaded successfully.
+ * Per-provider data-plane operations used by {@link verifyAndRetry}. Each
+ * provider supplies the bulk upload, a remote listing parsed into the same
+ * relative-key space as the local file set, and a single-file re-upload for the
+ * verify-and-retry pass. All argv is passed as discrete array tokens through the
+ * `exec` helpers (`shell: false`) — never a shell string (CLI-58 injection
+ * safety): a key containing shell metacharacters arrives as one opaque token.
+ */
+interface ProviderOps {
+    /** Provider CLI binary name (e.g. `gsutil`), for diagnostics. */
+    readonly cli: string;
+    /** Bulk-upload the whole assets dir. Throws on non-zero exit. */
+    bulkUpload(): void;
+    /**
+     * List remote objects under the bucket/prefix and return the set of keys,
+     * normalised to the SAME relative paths as {@link collectFiles} (i.e. with
+     * the provider scheme + bucket prefix stripped).
+     */
+    listRemote(): Set<string>;
+    /** Re-upload a single local file to its remote key. Throws on failure. */
+    reupload(key: string): void;
+}
+
+/**
+ * Shared verify-and-retry pass used by ALL providers (#75): list the remote
+ * prefix, diff against the local file set, re-upload any missing objects, then
+ * re-list and FAIL THE DEPLOY LOUDLY (throw → non-zero exit) naming any keys
+ * that are still missing. Per-file re-upload failures are logged with the
+ * object key + the underlying error before the deploy is failed.
+ */
+function verifyAndRetry(
+    ops: ProviderOps,
+    localFiles: readonly string[],
+    bucket: string,
+): void {
+    const remote = ops.listRemote();
+    let missing = localFiles.filter((f) => !remote.has(f));
+
+    if (missing.length === 0) {
+        log.info(
+            { provider: ops.cli, count: localFiles.length },
+            "All assets verified present after upload",
+        );
+        return;
+    }
+
+    log.warn(
+        { provider: ops.cli, count: missing.length },
+        "Files missing after bulk upload, retrying individually",
+    );
+
+    const reuploadFailures: string[] = [];
+    for (const key of missing) {
+        try {
+            ops.reupload(key);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            // Per-file error reporting: key + underlying error, not a count.
+            log.error(
+                { provider: ops.cli, key, error: message },
+                "Failed to re-upload missing asset",
+            );
+            reuploadFailures.push(key);
+        }
+    }
+
+    // Re-list and recompute what is STILL missing after the retry pass.
+    const remoteAfter = ops.listRemote();
+    missing = localFiles.filter((f) => !remoteAfter.has(f));
+
+    if (missing.length > 0) {
+        for (const key of missing) {
+            log.error(
+                { provider: ops.cli, key, bucket },
+                "Asset still missing after retry — upload incomplete",
+            );
+        }
+        throw new Error(
+            `Asset upload to ${ops.cli} bucket "${bucket}" incomplete: ` +
+                `${missing.length} object(s) still missing after retry: ` +
+                missing.join(", "),
+        );
+    }
+
+    log.info(
+        { provider: ops.cli, count: reuploadFailures.length },
+        "Missing files uploaded successfully on retry",
+    );
+}
+
+/** Strips a leading scheme/bucket prefix from a remote listing line. */
+function stripPrefix(line: string, prefix: string): string | null {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith(prefix)) {
+        return null;
+    }
+    return trimmed.slice(prefix.length);
+}
+
+/** Builds the {@link ProviderOps} for the configured storage provider. */
+function providerOps(
+    config: KnativeNextConfig,
+    assetsDir: string,
+): ProviderOps {
+    const { provider, bucket } = config.storage;
+    const cacheControl = "public, max-age=31536000, immutable";
+
+    switch (provider) {
+        case "gcs":
+            return {
+                cli: "gsutil",
+                bulkUpload() {
+                    runQuiet([
+                        "gsutil",
+                        "-m",
+                        "-h",
+                        `Cache-Control:${cacheControl}`,
+                        "cp",
+                        "-r",
+                        ...topLevelEntries(assetsDir),
+                        `gs://${bucket}/`,
+                    ]);
+                    // Ensure bucket has public read access for browser fetches.
+                    runQuiet([
+                        "gsutil",
+                        "iam",
+                        "ch",
+                        "allUsers:objectViewer",
+                        `gs://${bucket}`,
+                    ]);
+                },
+                listRemote() {
+                    const out = runCapture([
+                        "gsutil",
+                        "ls",
+                        "-r",
+                        `gs://${bucket}/`,
+                    ]);
+                    const prefix = `gs://${bucket}/`;
+                    const keys = new Set<string>();
+                    for (const line of out.split("\n")) {
+                        const key = stripPrefix(line, prefix);
+                        if (key) keys.add(key);
+                    }
+                    return keys;
+                },
+                reupload(key) {
+                    runQuiet([
+                        "gsutil",
+                        "-h",
+                        `Cache-Control:${cacheControl}`,
+                        "cp",
+                        join(assetsDir, key),
+                        `gs://${bucket}/${key}`,
+                    ]);
+                },
+            };
+
+        case "s3":
+            return {
+                cli: "aws",
+                bulkUpload() {
+                    runQuiet([
+                        "aws",
+                        "s3",
+                        "sync",
+                        assetsDir,
+                        `s3://${bucket}`,
+                        "--cache-control",
+                        cacheControl,
+                    ]);
+                },
+                listRemote() {
+                    // `--recursive` prints keys relative to the bucket root.
+                    const out = runCapture([
+                        "aws",
+                        "s3api",
+                        "list-objects-v2",
+                        "--bucket",
+                        bucket,
+                        "--query",
+                        "Contents[].Key",
+                        "--output",
+                        "text",
+                    ]);
+                    const keys = new Set<string>();
+                    // `--output text` is whitespace-separated; split on any.
+                    for (const tok of out.split(/\s+/)) {
+                        const key = tok.trim();
+                        if (key && key !== "None") keys.add(key);
+                    }
+                    return keys;
+                },
+                reupload(key) {
+                    runQuiet([
+                        "aws",
+                        "s3",
+                        "cp",
+                        join(assetsDir, key),
+                        `s3://${bucket}/${key}`,
+                        "--cache-control",
+                        cacheControl,
+                    ]);
+                },
+            };
+
+        case "minio":
+            return {
+                cli: "mc",
+                bulkUpload() {
+                    runQuiet([
+                        "mc",
+                        "cp",
+                        "--recursive",
+                        ...topLevelEntries(assetsDir),
+                        `minio/${bucket}/`,
+                    ]);
+                },
+                listRemote() {
+                    const out = runCapture([
+                        "mc",
+                        "ls",
+                        "--recursive",
+                        `minio/${bucket}/`,
+                    ]);
+                    const prefix = `minio/${bucket}/`;
+                    const keys = new Set<string>();
+                    for (const line of out.split("\n")) {
+                        const trimmed = line.trim();
+                        if (!trimmed) continue;
+                        // `mc ls --recursive` may print metadata columns then the
+                        // key; the key is the `minio/<bucket>/<key>` token if
+                        // present, else the last whitespace-delimited field.
+                        const token =
+                            trimmed
+                                .split(/\s+/)
+                                .find((t) => t.startsWith(prefix)) ??
+                            trimmed.split(/\s+/).pop();
+                        const key = token
+                            ? (stripPrefix(token, prefix) ?? token)
+                            : null;
+                        if (key) keys.add(key);
+                    }
+                    return keys;
+                },
+                reupload(key) {
+                    runQuiet([
+                        "mc",
+                        "cp",
+                        join(assetsDir, key),
+                        `minio/${bucket}/${key}`,
+                    ]);
+                },
+            };
+
+        case "azure":
+            return {
+                cli: "az",
+                bulkUpload() {
+                    runQuiet([
+                        "az",
+                        "storage",
+                        "blob",
+                        "upload-batch",
+                        "-d",
+                        bucket,
+                        "-s",
+                        assetsDir,
+                    ]);
+                },
+                listRemote() {
+                    const out = runCapture([
+                        "az",
+                        "storage",
+                        "blob",
+                        "list",
+                        "-c",
+                        bucket,
+                        "--query",
+                        "[].name",
+                        "-o",
+                        "json",
+                    ]);
+                    const keys = new Set<string>();
+                    try {
+                        const parsed = JSON.parse(out || "[]");
+                        if (Array.isArray(parsed)) {
+                            for (const name of parsed) {
+                                if (typeof name === "string" && name) {
+                                    keys.add(name);
+                                }
+                            }
+                        }
+                    } catch {
+                        // Tolerate non-JSON (empty container) — leaves keys empty
+                        // so verification reports the assets as missing.
+                    }
+                    return keys;
+                },
+                reupload(key) {
+                    runQuiet([
+                        "az",
+                        "storage",
+                        "blob",
+                        "upload",
+                        "-c",
+                        bucket,
+                        "-f",
+                        join(assetsDir, key),
+                        "-n",
+                        key,
+                    ]);
+                },
+            };
+
+        default:
+            throw new Error(`Unsupported storage provider: ${provider}`);
+    }
+}
+
+/**
+ * Uploads static assets to the configured storage provider, then runs a
+ * provider-agnostic verification pass (#75): every provider (GCS, S3, MinIO,
+ * Azure) lists the remote prefix, diffs it against the local `_next/static` +
+ * public file set, re-uploads any missing objects, and fails the deploy loudly
+ * (throws → non-zero exit) naming any keys still missing after retry. A partial
+ * or failed upload therefore produces a deploy-time signal instead of an app
+ * that 404s its own JS/CSS/images.
  */
 export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
     const assetsDir = join(process.cwd(), ".output", "public");
@@ -57,110 +379,9 @@ export async function uploadAssets(config: KnativeNextConfig): Promise<void> {
         "Syncing assets to storage",
     );
 
-    switch (config.storage.provider) {
-        case "gcs": {
-            // Upload with cache-control headers for immutable _next/static assets.
-            // The former shell glob `${assetsDir}/*` is expanded in Node (no shell)
-            // and each top-level entry passed as a discrete argv source.
-            runQuiet([
-                "gsutil",
-                "-m",
-                "-h",
-                "Cache-Control:public, max-age=31536000, immutable",
-                "cp",
-                "-r",
-                ...topLevelEntries(assetsDir),
-                `gs://${config.storage.bucket}/`,
-            ]);
-            // Ensure bucket has public read access for browser fetches
-            runQuiet([
-                "gsutil",
-                "iam",
-                "ch",
-                "allUsers:objectViewer",
-                `gs://${config.storage.bucket}`,
-            ]);
+    const ops = providerOps(config, assetsDir);
+    const localFiles = collectFiles(assetsDir, assetsDir);
 
-            // Post-upload verification: ensure all local files exist in GCS
-            const localFiles = collectFiles(assetsDir, assetsDir);
-            const gcsListResult = runCapture([
-                "gsutil",
-                "ls",
-                "-r",
-                `gs://${config.storage.bucket}/`,
-            ]);
-            const gcsFiles = new Set(
-                gcsListResult
-                    .split("\n")
-                    .filter((line) => line.startsWith("gs://"))
-                    .map((line) =>
-                        line.replace(`gs://${config.storage.bucket}/`, ""),
-                    ),
-            );
-
-            const missing = localFiles.filter((f) => !gcsFiles.has(f));
-
-            if (missing.length > 0) {
-                log.warn(
-                    { count: missing.length },
-                    "Files missing after bulk upload, retrying individually",
-                );
-                for (const file of missing) {
-                    const localPath = join(assetsDir, file);
-                    const gcsPath = `gs://${config.storage.bucket}/${file}`;
-                    runQuiet([
-                        "gsutil",
-                        "-h",
-                        "Cache-Control:public, max-age=31536000, immutable",
-                        "cp",
-                        localPath,
-                        gcsPath,
-                    ]);
-                }
-                log.info(
-                    { count: missing.length },
-                    "Missing files uploaded successfully",
-                );
-            }
-            break;
-        }
-        case "s3":
-            runQuiet([
-                "aws",
-                "s3",
-                "sync",
-                assetsDir,
-                `s3://${config.storage.bucket}`,
-                "--cache-control",
-                "public, max-age=31536000, immutable",
-            ]);
-            break;
-        case "minio":
-            // MinIO uses S3-compatible CLI. Former shell glob `${assetsDir}/*`
-            // expanded in Node so each top-level entry is a discrete argv source.
-            runQuiet([
-                "mc",
-                "cp",
-                "--recursive",
-                ...topLevelEntries(assetsDir),
-                `minio/${config.storage.bucket}/`,
-            ]);
-            break;
-        case "azure":
-            runQuiet([
-                "az",
-                "storage",
-                "blob",
-                "upload-batch",
-                "-d",
-                config.storage.bucket,
-                "-s",
-                assetsDir,
-            ]);
-            break;
-        default:
-            throw new Error(
-                `Unsupported storage provider: ${config.storage.provider}`,
-            );
-    }
+    ops.bulkUpload();
+    verifyAndRetry(ops, localFiles, config.storage.bucket);
 }


### PR DESCRIPTION
Closes #75

## What
Unifies post-upload **verification** across all four object-store providers (GCS, S3, MinIO, Azure). Each provider now exposes a small `ProviderOps` descriptor (`bulkUpload` / `listRemote` / `reupload`); a shared `verifyAndRetry()` lists the remote prefix, diffs against local files, re-uploads missing keys (logging key + error per failure), re-lists, and **throws naming any still-missing keys**. argv stays array-only through the `shell:false` exec helpers — no shell, no secrets in argv.

## Tests
- `vitest run`: **87/87 pass** (18 new). New `asset-upload.test.ts` mocks the real exec layer (`runQuiet`/`runCapture`) and, parametrized across all four providers (`describe.each`), asserts: correct provider CLI + argv, argv injection-safety, success uploads expected keys, partial-failure throws naming the missing key, verification catches a missing object.
- tsc clean (the one `@knext/lib/clients` error in `image-cache-sync.ts` is pre-existing, unrelated).

## Deferred
- Live cloud round-trip (real GCS/S3/MinIO/Azure) — `TODO(#75)`; not runnable without creds per the issue. Data plane fully exercised via the mocked exec layer; provider list-parsers written to the documented CLI output shapes, want one live smoke per provider when creds exist.

🤖 Drafted by knext-ship; pending review + sign-off.