### PR TITLE
Security: remove the mutating GET /api/cache/invalidate handler

### DIFF
--- a/apps/file-manager/scripts/http-probe.mjs
+++ b/apps/file-manager/scripts/http-probe.mjs
@@ -67,8 +67,10 @@ async function main() {
     `POST /api/cache/invalidate {tag:"products"} → HTTP ${inval1.status}: ${inval1.body}`,
   );
 
-  const inval2 = await get('/api/cache/invalidate?tag=files');
-  console.log(`GET /api/cache/invalidate?tag=files → HTTP ${inval2.status}: ${inval2.body}`);
+  // #78: invalidation is POST-only (a mutating GET is removed). The GET form
+  // would now 405.
+  const inval2 = await post('/api/cache/invalidate', { tag: 'files' });
+  console.log(`POST /api/cache/invalidate {tag:"files"} → HTTP ${inval2.status}: ${inval2.body}`);
 
   const od2 = await get('/cache-tests/on-demand');
   console.log(`GET /cache-tests/on-demand [after invalidation] → HTTP ${od2.status}`);

--- a/apps/file-manager/src/app/api/cache/invalidate/route.test.ts
+++ b/apps/file-manager/src/app/api/cache/invalidate/route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// revalidateTag touches Next.js internals that aren't available outside a
+// running server; stub it so we can exercise the authorized POST path.
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+
+import * as route from './route';
+import { POST } from './route';
+
+/**
+ * Issue #78: a GET must be side-effect-free. The mutating
+ * `GET /api/cache/invalidate?tag=…` handler is removed — only the
+ * authenticated, fail-closed POST remains as the invalidation entrypoint.
+ * (App Router automatically returns 405 for an unexported method.)
+ */
+function postReq(body: unknown, authorization?: string): Request {
+  return new Request('http://localhost/api/cache/invalidate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(authorization ? { authorization } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/cache/invalidate (issue #78)', () => {
+  const TOKEN = 'test-cache-token';
+
+  beforeEach(() => {
+    process.env.CACHE_INVALIDATE_TOKEN = TOKEN;
+  });
+  afterEach(() => {
+    process.env.CACHE_INVALIDATE_TOKEN = undefined;
+  });
+
+  it('exports NO GET handler (a mutating GET is removed)', () => {
+    expect((route as Record<string, unknown>).GET).toBeUndefined();
+    expect(typeof (route as Record<string, unknown>).GET).toBe('undefined');
+  });
+
+  it('still exports POST as the invalidation entrypoint', () => {
+    expect(typeof POST).toBe('function');
+  });
+
+  it('returns 401 with no Authorization header', async () => {
+    const res = await POST(postReq({ tag: 'files' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with a wrong token', async () => {
+    const res = await POST(postReq({ tag: 'files' }, 'Bearer wrong-token'));
+    expect(res.status).toBe(401);
+  });
+
+  it('fails closed when the token is not configured', async () => {
+    process.env.CACHE_INVALIDATE_TOKEN = undefined;
+    const res = await POST(postReq({ tag: 'files' }, 'Bearer anything'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 and invalidates with the correct token', async () => {
+    const res = await POST(postReq({ tag: 'files' }, `Bearer ${TOKEN}`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+  });
+
+  it('returns 400 on a missing tag (authorized)', async () => {
+    const res = await POST(postReq({}, `Bearer ${TOKEN}`));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/file-manager/src/app/api/cache/invalidate/route.ts
+++ b/apps/file-manager/src/app/api/cache/invalidate/route.ts
@@ -35,38 +35,8 @@ export async function POST(request: Request) {
   }
 }
 
-/**
- * GET /api/cache/invalidate?tag=files
- * Alternative GET-based invalidation for testing
- */
-export async function GET(request: any) {
-  // GET also mutates (invalidates) — same auth as POST. (A mutating GET is a smell;
-  // retire this handler once callers move to POST.)
-  if (!isAuthorized(request?.headers?.get?.('authorization'), process.env.CACHE_INVALIDATE_TOKEN)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-  let tag: string | null = null;
-  try {
-    const urlString = request?.url || request?.nextUrl?.href || 'http://localhost';
-    const parsedUrl = new URL(urlString);
-    tag = parsedUrl.searchParams?.get('tag');
-  } catch (e) {
-    console.warn('Failed to parse URL in cache invalidate route:', e);
-  }
-
-  if (!tag) {
-    return NextResponse.json(
-      { error: 'Missing "tag" query parameter', example: '/api/cache/invalidate?tag=files' },
-      { status: 400 },
-    );
-  }
-
-  // Trigger Next.js cache invalidation with stale-while-revalidate
-  revalidateTag(tag, 'max');
-
-  return NextResponse.json({
-    success: true,
-    message: `Cache invalidated for tag: ${tag}`,
-    timestamp: new Date().toISOString(),
-  });
-}
+// NOTE (#78): there is intentionally NO GET handler. Cache invalidation mutates
+// state, and a mutating GET is a security/operational hazard — prefetchable,
+// link-triggerable, and it leaks the Bearer token into URLs/logs. App Router
+// returns 405 automatically for the unexported GET method. POST is the only
+// invalidation entrypoint.

--- a/apps/file-manager/src/app/cache/page.tsx
+++ b/apps/file-manager/src/app/cache/page.tsx
@@ -57,7 +57,15 @@ export default function CacheMonitorPage() {
     setInvalidating(true);
     setMessage(null);
     try {
-      const res = await fetch(`/api/cache/invalidate?tag=${encodeURIComponent(invalidateTag)}`);
+      // Invalidation mutates state — must be POST, never a GET (#78). The
+      // Bearer token is a server-side secret (CACHE_INVALIDATE_TOKEN, K8s
+      // Secret) and is never exposed to the browser; this dev UI relies on an
+      // internal-only NetworkPolicy gating the endpoint.
+      const res = await fetch('/api/cache/invalidate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag: invalidateTag }),
+      });
       const data = await res.json();
       if (data.success) {
         setMessage(`✅ Invalidated tag: ${invalidateTag}`);

--- a/docs/security/mutating-endpoints.md
+++ b/docs/security/mutating-endpoints.md
@@ -22,8 +22,11 @@ grep -rln 'webhook\|Mutate\|Validate.*admission' packages/kn-next-operator/inter
 | Endpoint | Method | Mutates | Auth | Status |
 |---|---|---|---|---|
 | `/api/cache/invalidate` | POST | Next.js cache (`revalidateTag`) | Bearer token `CACHE_INVALIDATE_TOKEN`, fail-closed (`isAuthorized`) | ✅ authed |
-| `/api/cache/invalidate` | GET | same (a mutating GET — flagged smell; retire once callers move to POST) | same Bearer token | ✅ authed |
 | `/api/cache/events` | DELETE | clears all cache events (Redis / in-memory) | same Bearer token (reuses the single `isAuthorized` helper) | ✅ authed (E4-2) |
+
+There is intentionally **no `GET /api/cache/invalidate`** handler (#78): invalidation mutates state,
+and a mutating GET is prefetchable/link-triggerable and leaks the Bearer token into URLs and logs.
+App Router returns 405 for the unexported GET method; POST is the only invalidation entrypoint.
 
 Read-only handlers (no auth required, by design): `GET /api/cache/events`, `GET /api/health`,
 `GET /api/metrics`, `GET /api/audit`, `GET /api/cache-stats`. These disclose operational data only —


### PR DESCRIPTION
Closes #78.

A mutating GET /api/cache/invalidate?tag=… is a hazard even when auth-gated (prefetchable, link-triggerable, leaks the Bearer token into URLs/logs). Removes the GET export — App Router auto-405s the unexported method — leaving the fail-closed Bearer POST as the only invalidation entrypoint. POST auth (isAuthorized + CACHE_INVALIDATE_TOKEN, fail-closed) untouched.

Callers migrated to POST {tag}: dev UI cache/page.tsx, scripts/http-probe.mjs, and the docs/security/mutating-endpoints.md audit.

Test (RED-first, 7 cases): asserts no GET export, POST still 401 (no/wrong/unconfigured token) and 200 on authorized invalidation. 19 passed across the cache route tests.

Generated with Claude Code