### PR TITLE
Operator: emit Kubernetes Events and controller metrics on reconcile

### DIFF
--- a/packages/kn-next-operator/cmd/main.go
+++ b/packages/kn-next-operator/cmd/main.go
@@ -181,8 +181,9 @@ func main() {
 	}
 
 	if err := (&controller.NextAppReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nextapp-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NextApp")
 		os.Exit(1)

--- a/packages/kn-next-operator/config/rbac/role.yaml
+++ b/packages/kn-next-operator/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   - serviceaccounts
   verbs:

--- a/packages/kn-next-operator/go.mod
+++ b/packages/kn-next-operator/go.mod
@@ -5,6 +5,7 @@ go 1.25.3
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -46,13 +47,13 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/packages/kn-next-operator/internal/controller/metrics.go
+++ b/packages/kn-next-operator/internal/controller/metrics.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// knext-specific controller metrics. Cardinality is kept low on purpose: we label
+// only by reconcile result/reason, never by per-object name, to avoid metric explosion.
+var (
+	// reconcileTotal counts NextApp reconcile loops by result ("success" | "error").
+	reconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "knext_nextapp_reconcile_total",
+			Help: "Total number of NextApp reconcile loops, labeled by result.",
+		},
+		[]string{"result"},
+	)
+
+	// reconcileDuration observes the wall-clock duration of a reconcile loop.
+	reconcileDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "knext_nextapp_reconcile_duration_seconds",
+			Help:    "Duration of NextApp reconcile loops in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+
+	// reconcileErrors counts reconcile loops that returned an error.
+	reconcileErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "knext_nextapp_reconcile_errors_total",
+			Help: "Total number of NextApp reconcile loops that ended in error.",
+		},
+	)
+)
+
+func init() {
+	// Register with controller-runtime's global registry so the series are served on
+	// the existing /metrics endpoint alongside the built-in controller metrics.
+	metrics.Registry.MustRegister(reconcileTotal, reconcileDuration, reconcileErrors)
+}

--- a/packages/kn-next-operator/internal/controller/nextapp_controller.go
+++ b/packages/kn-next-operator/internal/controller/nextapp_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,10 +50,30 @@ const (
 	ConditionDegraded = "Degraded"
 )
 
+// Event reason constants — concise, stable strings surfaced via `kubectl describe nextapp`.
+const (
+	// ReasonInvalidImage marks a NextApp rejected for failing digest-pinning (e.g. :latest).
+	ReasonInvalidImage = "InvalidImage"
+	// ReasonReconcileFailed marks a generic reconcile error (API error, child create/update failure).
+	ReasonReconcileFailed = "ReconcileFailed"
+	// ReasonReconciled marks a successful reconcile.
+	ReasonReconciled = "Reconciled"
+)
+
 // NextAppReconciler reconciles a NextApp object
 type NextAppReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// Recorder emits Kubernetes Events attached to the NextApp so operators can see
+	// reconcile transitions via `kubectl describe`. May be nil in unit tests.
+	Recorder record.EventRecorder
+}
+
+// emitEvent records a Kubernetes Event on the NextApp when a recorder is wired.
+func (r *NextAppReconciler) emitEvent(obj runtime.Object, eventType, reason, message string) {
+	if r.Recorder != nil {
+		r.Recorder.Event(obj, eventType, reason, message)
+	}
 }
 
 // +kubebuilder:rbac:groups=apps.kn-next.dev,resources=nextapps,verbs=get;list;watch;create;update;patch;delete
@@ -61,9 +83,22 @@ type NextAppReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=caching.internal.knative.dev,resources=images,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	logger := logf.FromContext(ctx)
+
+	// Observe reconcile duration and tally the result on every return path.
+	start := time.Now()
+	defer func() {
+		reconcileDuration.Observe(time.Since(start).Seconds())
+		if retErr != nil {
+			reconcileTotal.WithLabelValues("error").Inc()
+			reconcileErrors.Inc()
+		} else {
+			reconcileTotal.WithLabelValues("success").Inc()
+		}
+	}()
 
 	var nextApp appsv1alpha1.NextApp
 	if err := r.Get(ctx, req.NamespacedName, &nextApp); err != nil {
@@ -89,6 +124,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// This was previously a warn-only check; A1-digest promotes it to a hard reject.
 	if err := validateImageRef(nextApp.Spec.Image); err != nil {
 		logger.Error(err, "Rejecting NextApp: image must be digest-pinned")
+		r.emitEvent(&nextApp, corev1.EventTypeWarning, ReasonInvalidImage,
+			fmt.Sprintf("Image rejected (must be digest-pinned, no :latest): %s", err.Error()))
 		apimeta.SetStatusCondition(&nextApp.Status.Conditions, metav1.Condition{
 			Type:               ConditionDegraded,
 			Status:             metav1.ConditionTrue,
@@ -120,6 +157,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	})
 	if err != nil {
 		logger.Error(err, "Failed to reconcile ServiceAccount")
+		r.emitEvent(&nextApp, corev1.EventTypeWarning, ReasonReconcileFailed,
+			fmt.Sprintf("Failed to reconcile ServiceAccount: %s", err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -147,6 +186,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		})
 		if err != nil {
 			logger.Error(err, "Failed to reconcile PVC")
+			r.emitEvent(&nextApp, corev1.EventTypeWarning, ReasonReconcileFailed,
+				fmt.Sprintf("Failed to reconcile bytecode-cache PVC: %s", err.Error()))
 			return ctrl.Result{}, err
 		}
 	}
@@ -385,6 +426,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	})
 	if err != nil {
 		logger.Error(err, "Failed to reconcile Knative Service")
+		r.emitEvent(&nextApp, corev1.EventTypeWarning, ReasonReconcileFailed,
+			fmt.Sprintf("Failed to reconcile Knative Service: %s", err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -419,6 +462,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		})
 		if err != nil {
 			logger.Error(err, "Failed to reconcile KafkaSource")
+			r.emitEvent(&nextApp, corev1.EventTypeWarning, ReasonReconcileFailed,
+				fmt.Sprintf("Failed to reconcile KafkaSource: %s", err.Error()))
 			return ctrl.Result{}, err
 		}
 	}
@@ -454,6 +499,8 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	r.emitEvent(&nextApp, corev1.EventTypeNormal, ReasonReconciled,
+		fmt.Sprintf("NextApp reconciled successfully (image %s)", nextApp.Spec.Image))
 	logger.Info("Successfully reconciled NextApp", "name", nextApp.Name, "url", nextApp.Status.URL)
 	return ctrl.Result{}, nil
 }

--- a/packages/kn-next-operator/internal/controller/nextapp_events_test.go
+++ b/packages/kn-next-operator/internal/controller/nextapp_events_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+)
+
+// drainEvents collects all currently-buffered events from a FakeRecorder without blocking.
+func drainEvents(rec *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+var _ = Describe("NextApp Controller Events & Metrics", func() {
+	ctx := context.Background()
+
+	Context("on a successful reconcile", func() {
+		const resourceName = "events-success"
+		nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+		BeforeEach(func() {
+			existing := &appsv1alpha1.NextApp{}
+			err := k8sClient.Get(ctx, nn, existing)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &appsv1alpha1.NextApp{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+					Spec: appsv1alpha1.NextAppSpec{
+						Image: "registry.example.com/app:v1@sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			resource := &appsv1alpha1.NextApp{}
+			if err := k8sClient.Get(ctx, nn, resource); err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("records a Normal Reconciled event and increments the success counter", func() {
+			recorder := record.NewFakeRecorder(64)
+			before := testutil.ToFloat64(reconcileTotal.WithLabelValues("success"))
+
+			r := &NextAppReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			events := drainEvents(recorder)
+			Expect(events).NotTo(BeEmpty())
+			found := false
+			for _, e := range events {
+				if strings.Contains(e, "Normal") && strings.Contains(e, "Reconciled") {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "expected a Normal Reconciled event, got: %v", events)
+
+			after := testutil.ToFloat64(reconcileTotal.WithLabelValues("success"))
+			Expect(after).To(BeNumerically(">", before))
+		})
+	})
+
+	Context("on a failure path (invalid :latest image)", func() {
+		const resourceName = "events-failure"
+		nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+		BeforeEach(func() {
+			existing := &appsv1alpha1.NextApp{}
+			err := k8sClient.Get(ctx, nn, existing)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &appsv1alpha1.NextApp{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+					Spec: appsv1alpha1.NextAppSpec{
+						// :latest must be rejected by validateImageRef.
+						Image: "registry.example.com/app:latest",
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			resource := &appsv1alpha1.NextApp{}
+			if err := k8sClient.Get(ctx, nn, resource); err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("records a Warning InvalidImage event and increments the error counter", func() {
+			recorder := record.NewFakeRecorder(64)
+			before := testutil.ToFloat64(reconcileErrors)
+
+			r := &NextAppReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).To(HaveOccurred())
+
+			events := drainEvents(recorder)
+			Expect(events).NotTo(BeEmpty())
+			found := false
+			for _, e := range events {
+				if strings.Contains(e, "Warning") && strings.Contains(e, "InvalidImage") {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "expected a Warning InvalidImage event, got: %v", events)
+
+			after := testutil.ToFloat64(reconcileErrors)
+			Expect(after).To(BeNumerically(">", before))
+		})
+	})
+})


### PR DESCRIPTION
Closes #79.

The operator emitted only log lines — kubectl describe nextapp showed nothing and there were no controller metrics to alert on. Adds:

**Events** (controller-runtime EventRecorder, attached to the NextApp):
- Warning InvalidImage — :latest/non-digest image rejected
- Warning ReconcileFailed — SA/PVC/ksvc/KafkaSource create-or-update errors
- Normal Reconciled — successful reconcile

**Metrics** (controller-runtime registry, served on the existing /metrics):
- knext_nextapp_reconcile_total{result=success|error}
- knext_nextapp_reconcile_duration_seconds (histogram)
- knext_nextapp_reconcile_errors_total

**Test (envtest, RED-first):** FakeRecorder asserts Normal/Reconciled on success and Warning/InvalidImage on a :latest failure path, plus metric counters increment (testutil.ToFloat64). 4/4 controller specs pass; go build + vet clean; RBAC events rule regenerated + committed (codegen stays clean).

Generated with Claude Code