### PR TITLE
Operator: validating admission webhook to reject invalid NextApp

### DIFF
--- a/packages/kn-next-operator/PROJECT
+++ b/packages/kn-next-operator/PROJECT
@@ -18,4 +18,7 @@ resources:
   kind: NextApp
   path: github.com/AhmedElBanna80/Knative-open-nextjs/packages/kn-next-operator/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/packages/kn-next-operator/cmd/main.go
+++ b/packages/kn-next-operator/cmd/main.go
@@ -37,6 +37,7 @@ import (
 
 	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
 	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/controller"
+	webhookv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/webhook/v1alpha1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	// +kubebuilder:scaffold:imports
 )
@@ -186,6 +187,20 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NextApp")
 		os.Exit(1)
+	}
+
+	// Register the NextApp validating admission webhook only when serving certs
+	// are configured. Without certs the webhook server cannot serve TLS, so we
+	// skip registration to keep `make run` / local development working. In a
+	// cluster, cert-manager mounts the cert and --webhook-cert-path is set, so
+	// the webhook is active and rejects invalid NextApps at admission time.
+	if len(webhookCertPath) > 0 {
+		if err := webhookv1alpha1.SetupNextAppWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create webhook", "webhook", "NextApp")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Skipping NextApp webhook registration: no --webhook-cert-path configured")
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/packages/kn-next-operator/config/certmanager/certificate.yaml
+++ b/packages/kn-next-operator/config/certmanager/certificate.yaml
@@ -1,0 +1,33 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: kn-next-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: kn-next-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  # Use wildcard in dnsNames to support both webhook-service and metrics-service.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/packages/kn-next-operator/config/certmanager/kustomization.yaml
+++ b/packages/kn-next-operator/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/packages/kn-next-operator/config/certmanager/kustomizeconfig.yaml
+++ b/packages/kn-next-operator/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution.
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/packages/kn-next-operator/config/default/kustomization.yaml
+++ b/packages/kn-next-operator/config/default/kustomization.yaml
@@ -18,11 +18,10 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+# [WEBHOOK] Validating admission webhook for NextApp (issue #77).
+- ../webhook
+# [CERTMANAGER] cert-manager provisions the webhook serving cert. 'WEBHOOK' components are required.
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -48,15 +47,86 @@ patches:
 #  target:
 #    kind: Deployment
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-#  target:
-#    kind: Deployment
+# [WEBHOOK] Mount the webhook serving cert + expose port 9443 on the manager (issue #77).
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
+# [CERTMANAGER] cert-manager CA injection: wire the serving Certificate's dnsNames to the
+# webhook Service name/namespace, and inject the CA bundle into the ValidatingWebhookConfiguration.
+replacements:
+# webhook-service name -> Certificate dnsNames[*] host segment
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
+      create: true
+# webhook-service namespace -> Certificate dnsNames[*] namespace segment
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+      create: true
+# serving-cert namespace -> ValidatingWebhookConfiguration cert-manager.io/inject-ca-from (namespace part)
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.namespace
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+      create: true
+# serving-cert name -> ValidatingWebhookConfiguration cert-manager.io/inject-ca-from (name part)
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+      create: true
+# --- The original commented metrics/conversion replacement scaffold follows (left disabled) ---
+#replacements_disabled:
 # - source: # Uncomment the following block to enable certificates for metrics
 #     kind: Service
 #     version: v1

--- a/packages/kn-next-operator/config/default/manager_webhook_patch.yaml
+++ b/packages/kn-next-operator/config/default/manager_webhook_patch.yaml
@@ -1,27 +1,29 @@
-# This patch ensures the webhook certificate is mounted into the manager
-# container and the webhook port is exposed. Applied via the [WEBHOOK] section
-# of config/default/kustomization.yaml.
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        volumeMounts:
-        - name: webhook-certs
-          mountPath: /tmp/k8s-webhook-server/serving-certs
-          readOnly: true
-      volumes:
-      - name: webhook-certs
-        secret:
-          secretName: webhook-server-cert
+# This patch mounts the webhook serving cert into the manager container and
+# exposes the webhook port. Applied via the [WEBHOOK] section of
+# config/default/kustomization.yaml.
+#
+# JSON6902 ops are used (matching manager_metrics_patch.yaml) so the webhook arg
+# is APPENDED to the base args (--leader-elect, --health-probe-bind-address=:8081)
+# rather than replacing the whole list — replacing it would silently disable
+# leader election (split-brain hazard with replicas>1).
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: webhook-certs
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/packages/kn-next-operator/config/default/manager_webhook_patch.yaml
+++ b/packages/kn-next-operator/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,27 @@
+# This patch ensures the webhook certificate is mounted into the manager
+# container and the webhook port is exposed. Applied via the [WEBHOOK] section
+# of config/default/kustomization.yaml.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert

--- a/packages/kn-next-operator/config/webhook/kustomization.yaml
+++ b/packages/kn-next-operator/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/packages/kn-next-operator/config/webhook/kustomizeconfig.yaml
+++ b/packages/kn-next-operator/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/packages/kn-next-operator/config/webhook/manifests.yaml
+++ b/packages/kn-next-operator/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-kn-next-dev-v1alpha1-nextapp
+  failurePolicy: Fail
+  name: vnextapp-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - apps.kn-next.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nextapps
+  sideEffects: None

--- a/packages/kn-next-operator/config/webhook/service.yaml
+++ b/packages/kn-next-operator/config/webhook/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/packages/kn-next-operator/internal/controller/nextapp_controller.go
+++ b/packages/kn-next-operator/internal/controller/nextapp_controller.go
@@ -35,6 +35,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/validation"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -85,23 +86,27 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Enforce digest pinning — validateImageRef rejects :latest and tag-only refs.
-	// This was previously a warn-only check; A1-digest promotes it to a hard reject.
-	if err := validateImageRef(nextApp.Spec.Image); err != nil {
-		logger.Error(err, "Rejecting NextApp: image must be digest-pinned")
+	// Validate the full spec using the SAME function the admission webhook calls
+	// (internal/validation.ValidateNextAppSpec) so the two cannot drift. This
+	// enforces digest pinning (rejects :latest / tag-only refs), required image,
+	// non-negative scaling, MinScale <= MaxScale, and recognized provider/queue
+	// enums. The webhook rejects these at write time; the reconciler stays
+	// fail-closed as defense-in-depth for CRs that predate the webhook.
+	if err := validation.ValidateNextAppSpec(&nextApp.Spec); err != nil {
+		logger.Error(err, "Rejecting NextApp: spec failed validation")
 		apimeta.SetStatusCondition(&nextApp.Status.Conditions, metav1.Condition{
 			Type:               ConditionDegraded,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: nextApp.Generation,
-			Reason:             "InvalidImage",
+			Reason:             "InvalidSpec",
 			Message:            err.Error(),
 		})
 		apimeta.SetStatusCondition(&nextApp.Status.Conditions, metav1.Condition{
 			Type:               ConditionReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: nextApp.Generation,
-			Reason:             "InvalidImage",
-			Message:            "Image does not meet digest-pinning requirements",
+			Reason:             "InvalidSpec",
+			Message:            "Spec does not meet validation requirements",
 		})
 		_ = r.Status().Update(ctx, &nextApp)
 		return ctrl.Result{}, err

--- a/packages/kn-next-operator/internal/controller/validate_image.go
+++ b/packages/kn-next-operator/internal/controller/validate_image.go
@@ -17,49 +17,15 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
-	"strings"
+	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/validation"
 )
 
 // validateImageRef enforces digest-pinning for all NextApp images.
 //
-// Acceptance rules (ADR-0001 / A1-digest):
-//   - ACCEPT:  image contains "@sha256:" — digest-pinned (with or without a tag)
-//   - REJECT:  image ends with ":latest" — mutable, prevents rollbacks
-//   - REJECT:  image has no "@sha256:" suffix — tag-only refs are mutable
-//   - REJECT:  image has no tag separator at all (implicitly :latest)
-//
-// This replaces the inline validation in Reconcile that only WARNED on :latest.
+// The digest-pinning logic now lives in internal/validation so the admission
+// webhook and the reconciler share a single implementation and cannot drift.
+// This thin wrapper is retained for the reconciler's existing call sites and
+// tests; it delegates to validation.ValidateImageRef.
 func validateImageRef(image string) error {
-	// A digest-pinned image MUST contain "@sha256:" — accept immediately.
-	if strings.Contains(image, "@sha256:") {
-		return nil
-	}
-
-	// No "@sha256:" — image is either tagless (implicit :latest) or tag-only.
-	// Both are rejected: tags are mutable and cannot guarantee provenance.
-
-	if strings.HasSuffix(image, ":latest") {
-		return fmt.Errorf(
-			"image %q uses the :latest tag which is forbidden: "+
-				"use a digest-pinned ref (e.g. myapp:v1@sha256:<hash>)",
-			image,
-		)
-	}
-
-	if !strings.Contains(image, ":") {
-		// No tag separator at all — registry resolves to :latest.
-		return fmt.Errorf(
-			"image %q has no explicit tag or digest: "+
-				"use a digest-pinned ref (e.g. myapp:v1@sha256:<hash>)",
-			image,
-		)
-	}
-
-	// Has a tag but no @sha256: — tag-only ref, still mutable.
-	return fmt.Errorf(
-		"image %q has a tag but no digest pin (@sha256:): "+
-			"use a digest-pinned ref (e.g. %s@sha256:<hash>)",
-		image, image,
-	)
+	return validation.ValidateImageRef(image)
 }

--- a/packages/kn-next-operator/internal/validation/validate.go
+++ b/packages/kn-next-operator/internal/validation/validate.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation holds the single, authoritative validation logic for a
+// NextApp spec. Both the validating admission webhook and the reconciler call
+// ValidateNextAppSpec so the two cannot drift: a NextApp that the webhook
+// rejects at write time is exactly the one the reconciler would refuse to act
+// on, and vice-versa.
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+)
+
+// Recognized enum values for the provider/queue free-form string fields.
+// These mirror the providers the CLI + reconciler actually wire up. They are
+// intentionally permissive supersets — unknown values are rejected so that a
+// typo (e.g. "gsc") fails at admission rather than silently producing a broken
+// Knative Service.
+var (
+	validStorageProviders = map[string]struct{}{
+		"gcs":   {},
+		"s3":    {},
+		"minio": {},
+		"azure": {},
+		"local": {},
+	}
+	validCacheProviders = map[string]struct{}{
+		"redis":  {},
+		"memory": {},
+	}
+	validRevalidationQueues = map[string]struct{}{
+		"kafka": {},
+	}
+)
+
+// ValidateImageRef enforces digest-pinning for all NextApp images.
+//
+// Acceptance rules (ADR-0001 / A1-digest):
+//   - ACCEPT:  image contains "@sha256:" — digest-pinned (with or without a tag)
+//   - REJECT:  image ends with ":latest" — mutable, prevents rollbacks
+//   - REJECT:  image has no "@sha256:" suffix — tag-only refs are mutable
+//   - REJECT:  image has no tag separator at all (implicitly :latest)
+//
+// This is the single source of truth for digest validation: the reconciler and
+// the admission webhook both reach it (the reconciler via validateImageRef,
+// which delegates here).
+func ValidateImageRef(image string) error {
+	// A digest-pinned image MUST contain "@sha256:" — accept immediately.
+	if strings.Contains(image, "@sha256:") {
+		return nil
+	}
+
+	// No "@sha256:" — image is either tagless (implicit :latest) or tag-only.
+	// Both are rejected: tags are mutable and cannot guarantee provenance.
+
+	if strings.HasSuffix(image, ":latest") {
+		return fmt.Errorf(
+			"image %q uses the :latest tag which is forbidden: "+
+				"use a digest-pinned ref (e.g. myapp:v1@sha256:<hash>)",
+			image,
+		)
+	}
+
+	if !strings.Contains(image, ":") {
+		// No tag separator at all — registry resolves to :latest.
+		return fmt.Errorf(
+			"image %q has no explicit tag or digest: "+
+				"use a digest-pinned ref (e.g. myapp:v1@sha256:<hash>)",
+			image,
+		)
+	}
+
+	// Has a tag but no @sha256: — tag-only ref, still mutable.
+	return fmt.Errorf(
+		"image %q has a tag but no digest pin (@sha256:): "+
+			"use a digest-pinned ref (e.g. %s@sha256:<hash>)",
+		image, image,
+	)
+}
+
+// ValidateNextAppSpec validates a NextApp spec and returns the first error
+// found, or nil if the spec is valid. It enforces:
+//
+//   - Image is required and digest-pinned (delegates to ValidateImageRef).
+//   - Scaling is non-negative and MinScale <= MaxScale (when MaxScale is set).
+//   - ContainerConcurrency is non-negative.
+//   - Storage.Provider / Cache.Provider / Revalidation.Queue, when set, are
+//     recognized enum values.
+//
+// This is the shared entry point used by both the webhook and the reconciler.
+func ValidateNextAppSpec(spec *appsv1alpha1.NextAppSpec) error {
+	if spec == nil {
+		return fmt.Errorf("spec is required")
+	}
+
+	// Image: required + digest-pinned.
+	if strings.TrimSpace(spec.Image) == "" {
+		return fmt.Errorf("spec.image is required")
+	}
+	if err := ValidateImageRef(spec.Image); err != nil {
+		return err
+	}
+
+	// Scaling sanity.
+	if spec.Scaling != nil {
+		s := spec.Scaling
+		if s.MinScale < 0 {
+			return fmt.Errorf("spec.scaling.minScale must be >= 0, got %d", s.MinScale)
+		}
+		if s.MaxScale < 0 {
+			return fmt.Errorf("spec.scaling.maxScale must be >= 0, got %d", s.MaxScale)
+		}
+		if s.ContainerConcurrency < 0 {
+			return fmt.Errorf("spec.scaling.containerConcurrency must be >= 0, got %d", s.ContainerConcurrency)
+		}
+		// MaxScale == 0 means "unbounded" in Knative, so only enforce the
+		// ordering when MaxScale is explicitly set to a positive value.
+		if s.MaxScale > 0 && s.MinScale > s.MaxScale {
+			return fmt.Errorf(
+				"spec.scaling.minScale (%d) must be <= maxScale (%d)",
+				s.MinScale, s.MaxScale,
+			)
+		}
+	}
+
+	// Provider / queue enums.
+	if spec.Storage != nil && spec.Storage.Provider != "" {
+		if _, ok := validStorageProviders[spec.Storage.Provider]; !ok {
+			return fmt.Errorf(
+				"spec.storage.provider %q is not recognized (valid: %s)",
+				spec.Storage.Provider, keys(validStorageProviders),
+			)
+		}
+	}
+	if spec.Cache != nil && spec.Cache.Provider != "" {
+		if _, ok := validCacheProviders[spec.Cache.Provider]; !ok {
+			return fmt.Errorf(
+				"spec.cache.provider %q is not recognized (valid: %s)",
+				spec.Cache.Provider, keys(validCacheProviders),
+			)
+		}
+	}
+	if spec.Revalidation != nil && spec.Revalidation.Queue != "" {
+		if _, ok := validRevalidationQueues[spec.Revalidation.Queue]; !ok {
+			return fmt.Errorf(
+				"spec.revalidation.queue %q is not recognized (valid: %s)",
+				spec.Revalidation.Queue, keys(validRevalidationQueues),
+			)
+		}
+	}
+
+	return nil
+}
+
+// keys returns the sorted-ish set keys for an error message. Order is not
+// guaranteed but the content is stable enough for human-readable errors.
+func keys(m map[string]struct{}) string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return strings.Join(out, ", ")
+}

--- a/packages/kn-next-operator/internal/validation/validate_test.go
+++ b/packages/kn-next-operator/internal/validation/validate_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+)
+
+const digestImage = "registry.example.com/app:v1@sha256:abc123def456"
+
+func TestValidateImageRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		wantErr bool
+	}{
+		{"digest pin only", "registry.example.com/app@sha256:abc123", false},
+		{"tag + digest", digestImage, false},
+		{"bare :latest", "registry.example.com/app:latest", true},
+		{"implicit latest (no tag)", "registry.example.com/app", true},
+		{"tag-only no digest", "registry.example.com/app:v1.2.3", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateImageRef(tc.image)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("ValidateImageRef(%q) err=%v, wantErr=%v", tc.image, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNextAppSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *appsv1alpha1.NextAppSpec
+		wantErr bool
+		errHas  string
+	}{
+		{
+			name:    "nil spec rejected",
+			spec:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "missing image rejected",
+			spec:    &appsv1alpha1.NextAppSpec{Image: ""},
+			wantErr: true,
+			errHas:  "image is required",
+		},
+		{
+			name:    "latest image rejected",
+			spec:    &appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"},
+			wantErr: true,
+			errHas:  ":latest",
+		},
+		{
+			name:    "tag-only image rejected",
+			spec:    &appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:v1.2.3"},
+			wantErr: true,
+		},
+		{
+			name:    "valid digest-pinned minimal spec accepted",
+			spec:    &appsv1alpha1.NextAppSpec{Image: digestImage},
+			wantErr: false,
+		},
+		{
+			name: "negative minScale rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: -1, MaxScale: 5},
+			},
+			wantErr: true,
+			errHas:  "minScale",
+		},
+		{
+			name: "minScale > maxScale rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 5, MaxScale: 2},
+			},
+			wantErr: true,
+			errHas:  "minScale",
+		},
+		{
+			name: "minScale <= maxScale accepted",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 1, MaxScale: 10},
+			},
+			wantErr: false,
+		},
+		{
+			name: "maxScale 0 (unbounded) with positive minScale accepted",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 3, MaxScale: 0},
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative containerConcurrency rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{ContainerConcurrency: -5},
+			},
+			wantErr: true,
+			errHas:  "containerConcurrency",
+		},
+		{
+			name: "unknown storage provider rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Storage: &appsv1alpha1.StorageSpec{Provider: "gsc"},
+			},
+			wantErr: true,
+			errHas:  "storage.provider",
+		},
+		{
+			name: "known storage provider accepted",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Storage: &appsv1alpha1.StorageSpec{Provider: "gcs"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown cache provider rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image: digestImage,
+				Cache: &appsv1alpha1.CacheSpec{Provider: "memcached"},
+			},
+			wantErr: true,
+			errHas:  "cache.provider",
+		},
+		{
+			name: "known cache provider accepted",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image: digestImage,
+				Cache: &appsv1alpha1.CacheSpec{Provider: "redis"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown revalidation queue rejected",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:        digestImage,
+				Revalidation: &appsv1alpha1.RevalidationSpec{Queue: "rabbitmq"},
+			},
+			wantErr: true,
+			errHas:  "revalidation.queue",
+		},
+		{
+			name: "known revalidation queue accepted",
+			spec: &appsv1alpha1.NextAppSpec{
+				Image:        digestImage,
+				Revalidation: &appsv1alpha1.RevalidationSpec{Queue: "kafka"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateNextAppSpec(tc.spec)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("ValidateNextAppSpec() err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if tc.errHas != "" && (err == nil || !strings.Contains(err.Error(), tc.errHas)) {
+				t.Fatalf("ValidateNextAppSpec() err=%v, want substring %q", err, tc.errHas)
+			}
+		})
+	}
+}

--- a/packages/kn-next-operator/internal/webhook/v1alpha1/nextapp_webhook.go
+++ b/packages/kn-next-operator/internal/webhook/v1alpha1/nextapp_webhook.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains the validating admission webhook for the NextApp
+// custom resource. It rejects invalid NextApps at write time, before the API
+// server persists them — defense-in-depth on top of the reconciler's
+// fail-closed validation. Webhook and reconciler share a single validation
+// function (internal/validation.ValidateNextAppSpec) so they cannot drift.
+package v1alpha1
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/validation"
+)
+
+// nextAppLog is for logging in this package.
+var nextAppLog = logf.Log.WithName("nextapp-webhook")
+
+// SetupNextAppWebhookWithManager registers the validating webhook for the
+// NextApp resource with the manager.
+func SetupNextAppWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &appsv1alpha1.NextApp{}).
+		WithValidator(&NextAppCustomValidator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-apps-kn-next-dev-v1alpha1-nextapp,mutating=false,failurePolicy=fail,sideEffects=None,groups=apps.kn-next.dev,resources=nextapps,verbs=create;update,versions=v1alpha1,name=vnextapp-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// NextAppCustomValidator validates NextApp resources at admission time. It
+// implements admission.Validator[*NextApp] and delegates to the shared
+// validation.ValidateNextAppSpec so admission and reconcile cannot diverge.
+type NextAppCustomValidator struct{}
+
+var _ admission.Validator[*appsv1alpha1.NextApp] = &NextAppCustomValidator{}
+
+// ValidateCreate validates the spec when a NextApp is created.
+func (v *NextAppCustomValidator) ValidateCreate(_ context.Context, nextApp *appsv1alpha1.NextApp) (admission.Warnings, error) {
+	nextAppLog.Info("Validating NextApp on create", "name", nextApp.GetName())
+	return nil, validation.ValidateNextAppSpec(&nextApp.Spec)
+}
+
+// ValidateUpdate validates the spec when a NextApp is updated.
+func (v *NextAppCustomValidator) ValidateUpdate(_ context.Context, _, newApp *appsv1alpha1.NextApp) (admission.Warnings, error) {
+	nextAppLog.Info("Validating NextApp on update", "name", newApp.GetName())
+	return nil, validation.ValidateNextAppSpec(&newApp.Spec)
+}
+
+// ValidateDelete is a no-op: deletes are always allowed.
+func (v *NextAppCustomValidator) ValidateDelete(_ context.Context, _ *appsv1alpha1.NextApp) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/packages/kn-next-operator/internal/webhook/v1alpha1/nextapp_webhook_test.go
+++ b/packages/kn-next-operator/internal/webhook/v1alpha1/nextapp_webhook_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+)
+
+const digestImage = "registry.example.com/app:v1@sha256:abc123def456"
+
+func newNextApp(spec appsv1alpha1.NextAppSpec) *appsv1alpha1.NextApp {
+	return &appsv1alpha1.NextApp{Spec: spec}
+}
+
+func TestValidateCreate(t *testing.T) {
+	v := &NextAppCustomValidator{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		obj     *appsv1alpha1.NextApp
+		wantErr bool
+	}{
+		{
+			name:    "latest image rejected",
+			obj:     newNextApp(appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"}),
+			wantErr: true,
+		},
+		{
+			name:    "missing image rejected",
+			obj:     newNextApp(appsv1alpha1.NextAppSpec{Image: ""}),
+			wantErr: true,
+		},
+		{
+			name: "minScale > maxScale rejected",
+			obj: newNextApp(appsv1alpha1.NextAppSpec{
+				Image:   digestImage,
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 5, MaxScale: 1},
+			}),
+			wantErr: true,
+		},
+		{
+			name:    "valid digest-pinned accepted",
+			obj:     newNextApp(appsv1alpha1.NextAppSpec{Image: digestImage}),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := v.ValidateCreate(ctx, tc.obj)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("ValidateCreate() err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	v := &NextAppCustomValidator{}
+	ctx := context.Background()
+
+	old := newNextApp(appsv1alpha1.NextAppSpec{Image: digestImage})
+
+	// Updating to a :latest image must be rejected.
+	bad := newNextApp(appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"})
+	if _, err := v.ValidateUpdate(ctx, old, bad); err == nil {
+		t.Fatalf("ValidateUpdate() to :latest image = nil; want error")
+	} else if !strings.Contains(err.Error(), ":latest") {
+		t.Fatalf("ValidateUpdate() err=%v, want :latest message", err)
+	}
+
+	// Updating to another valid digest-pinned image is allowed.
+	good := newNextApp(appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:v2@sha256:deadbeef"})
+	if _, err := v.ValidateUpdate(ctx, old, good); err != nil {
+		t.Fatalf("ValidateUpdate() valid = %v; want nil", err)
+	}
+}
+
+func TestValidateDeleteIsNoOp(t *testing.T) {
+	v := &NextAppCustomValidator{}
+	// Even an invalid spec must be deletable.
+	bad := newNextApp(appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"})
+	if _, err := v.ValidateDelete(context.Background(), bad); err != nil {
+		t.Fatalf("ValidateDelete() = %v; want nil (no-op)", err)
+	}
+}

--- a/packages/kn-next-operator/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/packages/kn-next-operator/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+)
+
+// This suite installs the NextApp validating webhook into an envtest API server
+// and asserts that the API server itself rejects invalid NextApp writes at
+// admission time (acceptance criteria for issue #77).
+
+var (
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	Expect(appsv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(admissionv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	By("bootstrapping test environment with the validating webhook")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+	if dir := firstEnvTestBinaryDir(); dir != "" {
+		testEnv.BinaryAssetsDirectory = dir
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("starting the webhook manager")
+	webhookOpts := testEnv.WebhookInstallOptions
+	mgr, err := manager.New(cfg, manager.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookOpts.LocalServingHost,
+			Port:    webhookOpts.LocalServingPort,
+			CertDir: webhookOpts.LocalServingCertDir,
+		}),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(SetupNextAppWebhookWithManager(mgr)).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+
+	// Wait for the webhook server's TLS endpoint to come up.
+	dialAddr := fmt.Sprintf("%s:%d", webhookOpts.LocalServingHost, webhookOpts.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(&net.Dialer{Timeout: time.Second}, "tcp", dialAddr,
+			&tls.Config{InsecureSkipVerify: true}) // #nosec G402 -- test-only self-signed cert
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	if cancel != nil {
+		cancel()
+	}
+	if testEnv != nil {
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+})
+
+var _ = Describe("NextApp validating webhook (envtest)", func() {
+	const ns = "default"
+
+	mkApp := func(name string, spec appsv1alpha1.NextAppSpec) *appsv1alpha1.NextApp {
+		return &appsv1alpha1.NextApp{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       spec,
+		}
+	}
+
+	It("rejects a :latest image at admission", func() {
+		err := k8sClient.Create(context.Background(),
+			mkApp("latest-img", appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:latest"}))
+		Expect(err).To(HaveOccurred())
+		Expect(strings.ToLower(err.Error())).To(ContainSubstring("latest"))
+	})
+
+	It("rejects a tag-only image at admission", func() {
+		err := k8sClient.Create(context.Background(),
+			mkApp("tag-only", appsv1alpha1.NextAppSpec{Image: "registry.example.com/app:v1.2.3"}))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects minScale > maxScale at admission", func() {
+		err := k8sClient.Create(context.Background(),
+			mkApp("bad-scale", appsv1alpha1.NextAppSpec{
+				Image:   "registry.example.com/app@sha256:abc123",
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 5, MaxScale: 1},
+			}))
+		Expect(err).To(HaveOccurred())
+		Expect(strings.ToLower(err.Error())).To(ContainSubstring("minscale"))
+	})
+
+	It("admits a valid digest-pinned NextApp", func() {
+		err := k8sClient.Create(context.Background(),
+			mkApp("valid-app", appsv1alpha1.NextAppSpec{
+				Image:   "registry.example.com/app:v1@sha256:abc123def456",
+				Scaling: &appsv1alpha1.ScalingSpec{MinScale: 1, MaxScale: 10},
+			}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+func firstEnvTestBinaryDir() string {
+	base := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			return filepath.Join(base, e.Name())
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #77.

Validation ran only during reconcile, so the API server ACCEPTED an invalid NextApp (unpinned image, malformed spec) — kubectl apply succeeded and the failure surfaced later as a Degraded condition. This adds an admission-time gate.

**Shared validation (no drift):** a new internal/validation.ValidateNextAppSpec enforces required + digest-pinned image (reusing the exact :latest/tag-only logic, not duplicated), non-negative scaling, MinScale<=MaxScale, and recognized Storage/Cache/Revalidation enums. Both the reconciler and the webhook call it; validate_image.go is now a thin wrapper — the :latest rejection is unchanged and shared.

**Webhook:** a controller-runtime CustomValidator (ValidateCreate/Update; Delete no-op) wired in cmd/main.go (guarded behind --webhook-cert-path so local run still works), with config/webhook + config/certmanager overlays and CA injection.

**Tests (envtest):** the webhook suite installs the webhook in envtest and asserts the API server REJECTS :latest, tag-only, and MinScale>MaxScale, and ADMITS a valid digest-pinned NextApp; plus shared-validator + ValidateCreate unit tests.

**Verified:** go build + vet clean; make manifests generate leaves an empty git diff (codegen committed); full go test suite green incl. the envtest webhook suite.

Generated with Claude Code