### PR TITLE
Ingress: operator-managed declarative Kourier ingress-class (#45)

### DIFF
--- a/.claude/skills/knative-kubernetes/SKILL.md
+++ b/.claude/skills/knative-kubernetes/SKILL.md
@@ -54,8 +54,13 @@ kubectl apply -f https://github.com/knative/serving/releases/download/knative-vX
 kubectl apply -f https://github.com/knative/serving/releases/download/knative-vX/serving-core.yaml
 kubectl apply -f https://github.com/knative-extensions/net-kourier/releases/download/knative-vX/kourier.yaml
 kubectl patch cm/config-network -n knative-serving --type merge \
-  -p '{"data":{"ingress-class":"kourier.knative.dev"}}'
+  -p '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
 ```
+The full controller-qualified `kourier.ingress.networking.knative.dev` is the correct
+ingress-class — the short `kourier.knative.dev` form does NOT match Kourier's class and
+leaves routes unprogrammed. The operator install bundle now ships this `config-network`
+ConfigMap declaratively (issue #45 / ADR-0009), so manual patching is only needed for a
+hand-rolled dev install.
 ⚠️ Match the Knative version to the cluster's k8s version (Knative ≤1.19 predates k8s 1.34).
 
 ## Debugging

--- a/docs/MATURITY_PLAN.md
+++ b/docs/MATURITY_PLAN.md
@@ -27,8 +27,12 @@
 - **Stale docs** — `VINEXT_MIGRATION_PLAN.md`, vinext mentions in `ARCHITECTURE.md`.
 - **No compat-suite gate** — correctness is unverified.
 - **Image optimization dropped** — `sharp` removed (no `next/image` optimization) — a parity gap.
-- **Networking layer unproven** — Kourier failed to program ingress on k8s 1.34 during OKE
-  validation (port-forward/LB-to-pod used as workaround). Needs an ADR + a supported path.
+- **Networking layer** — Kourier appeared to "fail to program ingress on k8s 1.34" during OKE
+  validation, but the real root cause was an **unset `ingress-class`** in Knative Serving's
+  `config-network` ConfigMap, so Serving never wired routes to the installed Kourier ingress.
+  Now codified declaratively: the operator install bundle ships a `config-network` ConfigMap
+  setting `ingress-class: kourier.ingress.networking.knative.dev` (issue #45, ADR-0009),
+  replacing the manual `kubectl patch`.
 
 ## Phases (sequential; each gated by exit criteria)
 

--- a/docs/adr/0009-kourier-ingress-class.md
+++ b/docs/adr/0009-kourier-ingress-class.md
@@ -1,0 +1,84 @@
+# ADR-0009: Operator-managed Kourier ingress-class via a declarative bundle ConfigMap
+
+- Status: Accepted
+- Date: 2026-06-22
+- Deciders: knext architect
+- Related: ADR-0001 (operator = single source of truth), issue #45 (Kourier ingress-class),
+  `.claude/skills/knative-kubernetes/SKILL.md`, `docs/MATURITY_PLAN.md` (networking layer)
+
+## Context
+
+During OKE validation, knext apps were unreachable through the ingress and the symptom was
+diagnosed as **"Kourier broken on k8s 1.34."** That diagnosis was **wrong**. The real cause:
+Knative Serving's `config-network` ConfigMap (namespace `knative-serving`) left `ingress-class`
+**unset**, so Serving never programmed routes against the installed Kourier ingress. The workaround
+was a manual, undocumented, easy-to-forget step:
+
+```sh
+kubectl patch cm/config-network -n knative-serving --type merge \
+  -p '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
+```
+
+This violates ADR-0001 in spirit: a hand-run `kubectl patch` is out-of-band cluster mutation that
+the install bundle does not own. We want the ingress-class set **declaratively** as part of the
+operator's installable bundle, so a single `kubectl apply` of `install.yaml` produces a working
+ingress with no manual follow-up.
+
+A secondary defect: the correct ingress-class is the full controller-qualified form
+`kourier.ingress.networking.knative.dev`. Some internal docs carried a short `kourier.knative.dev`
+form, which does **not** match Kourier's ingress class and leaves routes unprogrammed. That drift is
+corrected alongside this ADR.
+
+## Decision
+
+1. **Ship a declarative `config-network` ConfigMap in the install bundle.**
+   `config/knative/config-network.yaml` defines a `ConfigMap` named `config-network` in the
+   `knative-serving` namespace with `data.ingress-class: kourier.ingress.networking.knative.dev`. It
+   is wired into the bundle via `config/knative/kustomization.yaml` → `config/default` (`- ../knative`).
+2. **Apply with `kubectl apply --server-side`** so the ConfigMap **merges** into the one Knative
+   Serving already owns (it holds other networking keys) rather than clobbering it. Documented in the
+   operator README.
+3. **Namespace/name immunity.** `config/default` applies `namespace: kn-next-operator-system` and
+   `namePrefix: kn-next-operator-` to every resource, which would rewrite this ConfigMap to
+   `kn-next-operator-config-network` in `kn-next-operator-system` — where Serving would never read it.
+   A `transformers:` entry (`config/default/config_network_repin.yaml`, a builtin `PatchTransformer`)
+   runs **after** the built-in namespace/namePrefix transformers and re-pins both the name
+   (`config-network`) and namespace (`knative-serving`). A test asserts the rendered bundle keeps the
+   correct namespace.
+
+## Options considered
+
+| Option | What | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| (a) `KnativeServing` CR | Install the Knative Operator and set network config via its CR | Canonical Knative config surface | Pulls in the **whole Knative Operator**; the repo uses raw `serving-core` everywhere — a large, unwanted dependency | Rejected |
+| (b) Go reconciler | A controller that writes `config-network` in `knative-serving` | Self-healing; drift correction | Needs **foreign-namespace ConfigMap RBAC** (write into `knative-serving`); runtime complexity for a one-shot config | Rejected (now) |
+| (c) Declarative bundle ConfigMap | Ship `config-network` in `install.yaml` | Bundle-owned + declarative (ADR-0001-compliant); zero new RBAC, no API types, no runtime read/write; single `apply` | One-shot — does not self-heal if a human later un-sets the key | **Chosen** |
+
+## Consequences
+
+- The manual `kubectl patch` step is gone; `kubectl apply --server-side` of `install.yaml` yields a
+  working ingress-class.
+- No new RBAC, no new API types, no runtime read/write. `make manifests` / `make generate` produce
+  no diff.
+- **Drift correction, not self-healing:** if an operator later edits `config-network` and removes the
+  key, the bundle does not re-assert it until the next `apply`. **Upgrade path:** if drift becomes a
+  real operational problem, promote to option (b) — a small reconciler with scoped
+  `knative-serving` ConfigMap RBAC. The declarative ConfigMap is forward-compatible with that.
+- **Harness mismatch (flagged, not silently flipped):** the operator's local kind/e2e harness and
+  Knative install scripts target **net-istio** in places, while this config is **kourier-only**. We do
+  not flip the harness to net-kourier as part of this change — that is a separate, deliberate decision
+  with its own validation. Until then, this ConfigMap is correct for the **kourier** production path
+  (OKE) and inert/wrong for an istio-based dev cluster. Anyone standing up a kourier dev cluster gets
+  the right value; anyone on istio must not apply the kourier ingress-class. Track aligning the
+  harness to net-kourier as follow-up.
+
+## Action items
+
+- [x] `config/knative/config-network.yaml` + `config/knative/kustomization.yaml`.
+- [x] Wire `- ../knative` into `config/default/kustomization.yaml` with a post-transform repin so the
+      rendered ConfigMap stays `config-network` in `knative-serving`.
+- [x] Tests: source-manifest assertion + rendered-bundle namespace-immunity assertion.
+- [x] Docs: operator README prerequisite + `--server-side`; `docs/MATURITY_PLAN.md` root-cause fix;
+      skill ingress-class drift fix.
+- [ ] Follow-up: align the e2e/kind harness to net-kourier (or document the istio dev path
+      explicitly), then re-evaluate option (b) if config drift is observed in practice.

--- a/packages/kn-next-operator/README.md
+++ b/packages/kn-next-operator/README.md
@@ -11,19 +11,31 @@ The operator image is built, SBOM'd, Trivy-scanned (fail on HIGH/CRITICAL),
 cosign-signed, and pushed to `ghcr.io/getknext-dev/kn-next-operator` by
 [`.github/workflows/operator-supply-chain.yml`](../../.github/workflows/operator-supply-chain.yml).
 Each `main` build also publishes a digest-pinned `install.yaml` bundle (CRDs + RBAC +
-manager Deployment + webhook + cert-manager resources).
+manager Deployment + webhook + cert-manager resources + the Knative `config-network`
+ConfigMap that sets the Kourier ingress-class — issue #45 / ADR-0009).
 
 Install knext's control plane with a single apply:
 
 ```sh
-kubectl apply -f https://github.com/getknext-dev/knext/releases/latest/download/install.yaml
+kubectl apply --server-side -f https://github.com/getknext-dev/knext/releases/latest/download/install.yaml
 ```
 
+> Use `--server-side` so the bundle's `config-network` ConfigMap **merges** into the
+> one Knative Serving already owns (which holds other networking keys) instead of
+> clobbering it.
+>
 > The bundle's manager image is **digest-pinned** (`@sha256:…`); it never uses
 > `:latest` (enforced by `hack/check-no-latest.sh`).
 >
-> Prerequisite: [cert-manager](https://cert-manager.io) must be installed in the
-> cluster (the bundle includes the operator's `Issuer`/`Certificate` for its webhook).
+> Prerequisites:
+> - [cert-manager](https://cert-manager.io) must be installed in the cluster (the
+>   bundle includes the operator's `Issuer`/`Certificate` for its webhook).
+> - **Knative Serving + Kourier** must be installed. The bundle ships a
+>   `config-network` ConfigMap (`namespace: knative-serving`) that pins
+>   `ingress-class: kourier.ingress.networking.knative.dev` — the full
+>   controller-qualified form. Without it, Serving leaves the ingress-class unset and
+>   never wires routes to Kourier (this was the real cause of the OKE "Kourier broken
+>   on k8s 1.34" symptom — see ADR-0009).
 
 ### Verify the signature (optional)
 

--- a/packages/kn-next-operator/config/default/config_network_repin.yaml
+++ b/packages/kn-next-operator/config/default/config_network_repin.yaml
@@ -1,0 +1,25 @@
+# issue #45: namespace/name immunity for the operator-managed config-network ConfigMap.
+#
+# config/default applies `namespace: kn-next-operator-system` and
+# `namePrefix: kn-next-operator-` to EVERY resource. That would rewrite this
+# ConfigMap to `kn-next-operator-config-network` in `kn-next-operator-system`, where
+# Knative Serving would never read it. Knative Serving requires the ConfigMap to be
+# exactly `config-network` in the `knative-serving` namespace.
+#
+# A `transformers:` entry runs AFTER the built-in namespace + namePrefix
+# transformers, so this PatchTransformer can put both fields back. The target regex
+# matches the prefixed name.
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: config-network-repin
+patch: |-
+  - op: replace
+    path: /metadata/name
+    value: config-network
+  - op: replace
+    path: /metadata/namespace
+    value: knative-serving
+target:
+  kind: ConfigMap
+  name: .*config-network

--- a/packages/kn-next-operator/config/default/kustomization.yaml
+++ b/packages/kn-next-operator/config/default/kustomization.yaml
@@ -18,6 +18,12 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+# [KNATIVE] Operator-managed config-network ConfigMap that sets the Kourier
+# ingress-class (issue #45). It must stay named config-network in the
+# knative-serving namespace; the config_network_repin transformer below re-pins
+# both name and namespace AFTER the top-level `namespace:`/`namePrefix:`
+# transformers rewrite every resource to kn-next-operator-{system,*}.
+- ../knative
 # [WEBHOOK] Validating admission webhook for NextApp (issue #77).
 - ../webhook
 # [CERTMANAGER] cert-manager provisions the webhook serving cert. 'WEBHOOK' components are required.
@@ -31,6 +37,11 @@ resources:
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
+
+# [KNATIVE] Runs after the built-in namespace/namePrefix transformers to re-pin the
+# config-network ConfigMap to its required name + namespace (issue #45).
+transformers:
+- config_network_repin.yaml
 
 # Uncomment the patches line if you enable Metrics
 patches:

--- a/packages/kn-next-operator/config/knative/config-network.yaml
+++ b/packages/kn-next-operator/config/knative/config-network.yaml
@@ -1,0 +1,25 @@
+# config-network: operator-managed Knative Serving network config (issue #45).
+#
+# This codifies the Kourier ingress-class fix DECLARATIVELY, replacing the manual
+# `kubectl patch configmap config-network -n knative-serving ...` step.
+#
+# Root cause (corrected): cluster traffic failed not because "Kourier is broken on
+# k8s 1.34" (an earlier, wrong diagnosis) but because Knative Serving's
+# config-network ConfigMap left `ingress-class` unset, so Serving never wired routes
+# to the installed Kourier ingress. Setting it explicitly fixes routing.
+#
+# The value MUST be the full controller-qualified form below — the short
+# `kourier.knative.dev` form is drift and does not match Kourier's ingress class.
+#
+# Apply with `kubectl apply --server-side` so this merges into any existing
+# config-network managed by the Knative Serving install (it owns other keys).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+data:
+  ingress-class: kourier.ingress.networking.knative.dev

--- a/packages/kn-next-operator/config/knative/kustomization.yaml
+++ b/packages/kn-next-operator/config/knative/kustomization.yaml
@@ -3,9 +3,9 @@
 #
 # This is pinned to the knative-serving namespace. When included from
 # config/default (which applies `namespace: kn-next-operator-system` to all
-# resources), the parent must neutralize that transformer for this ConfigMap so the
-# rendered output keeps `namespace: knative-serving` — see config/default's
-# unsetonly namespace transformer config.
+# resources), that namespace would be rewritten — so config/default re-pins this
+# ConfigMap back to `config-network` / `knative-serving` with a PatchTransformer
+# (config_network_repin.yaml) that runs AFTER the namespace/namePrefix transformers.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/packages/kn-next-operator/config/knative/kustomization.yaml
+++ b/packages/kn-next-operator/config/knative/kustomization.yaml
@@ -1,0 +1,15 @@
+# Operator-managed Knative network config (issue #45): the declarative
+# config-network ConfigMap that sets the Kourier ingress-class.
+#
+# This is pinned to the knative-serving namespace. When included from
+# config/default (which applies `namespace: kn-next-operator-system` to all
+# resources), the parent must neutralize that transformer for this ConfigMap so the
+# rendered output keeps `namespace: knative-serving` — see config/default's
+# unsetonly namespace transformer config.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: knative-serving
+
+resources:
+- config-network.yaml

--- a/packages/kn-next-operator/internal/install/ingress_class_test.go
+++ b/packages/kn-next-operator/internal/install/ingress_class_test.go
@@ -1,0 +1,97 @@
+// Package install also verifies the operator-managed Kourier ingress-class config
+// (issue #45): the install bundle ships a declarative `config-network` ConfigMap in
+// the knative-serving namespace that sets the ingress-class to the full Kourier form
+// (kourier.ingress.networking.knative.dev), codifying the previously-manual
+// `kubectl patch` and immune to the bundle's namespace transformer.
+package install
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	wantConfigNetworkName = "config-network"
+	wantKnativeNamespace  = "knative-serving"
+	wantIngressClass      = "kourier.ingress.networking.knative.dev"
+)
+
+// TestConfigNetworkManifestSetsKourierIngressClass asserts the source manifest
+// config/knative/config-network.yaml is a ConfigMap named config-network in the
+// knative-serving namespace with the full Kourier ingress-class.
+func TestConfigNetworkManifestSetsKourierIngressClass(t *testing.T) {
+	raw := repoFile(t, "config/knative/config-network.yaml")
+
+	var obj struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("decoding config-network.yaml: %v", err)
+	}
+
+	if obj.Kind != "ConfigMap" {
+		t.Errorf("kind = %q, want ConfigMap", obj.Kind)
+	}
+	if obj.Metadata.Name != wantConfigNetworkName {
+		t.Errorf("metadata.name = %q, want %q", obj.Metadata.Name, wantConfigNetworkName)
+	}
+	if obj.Metadata.Namespace != wantKnativeNamespace {
+		t.Errorf("metadata.namespace = %q, want %q", obj.Metadata.Namespace, wantKnativeNamespace)
+	}
+	if got := obj.Data["ingress-class"]; got != wantIngressClass {
+		t.Errorf("data[ingress-class] = %q, want %q", got, wantIngressClass)
+	}
+}
+
+// TestInstallBundleCarriesKourierIngressClass proves the kustomize wiring +
+// namespace immunity: the rendered dist/install.yaml must contain the config-network
+// ConfigMap STILL in knative-serving (not rewritten to the operator namespace by the
+// top-level namespace transformer) with the kourier ingress-class. Skip cleanly when
+// the bundle has not been generated (run `make build-installer`).
+func TestInstallBundleCarriesKourierIngressClass(t *testing.T) {
+	if _, err := os.Stat(filepath.Join("..", "..", "dist", "install.yaml")); err != nil {
+		t.Skip("dist/install.yaml not generated (run `make build-installer`)")
+	}
+	raw := repoFile(t, "dist/install.yaml")
+	dec := yaml.NewDecoder(strings.NewReader(raw))
+
+	found := false
+	for {
+		var obj map[string]any
+		if err := dec.Decode(&obj); err != nil {
+			break
+		}
+		if len(obj) == 0 {
+			continue
+		}
+		if obj["kind"] != "ConfigMap" {
+			continue
+		}
+		meta, _ := obj["metadata"].(map[string]any)
+		if meta == nil || meta["name"] != wantConfigNetworkName {
+			continue
+		}
+		found = true
+		if meta["namespace"] != wantKnativeNamespace {
+			t.Errorf("config-network namespace = %v, want %q (namespace transformer must not rewrite it)",
+				meta["namespace"], wantKnativeNamespace)
+		}
+		data, _ := obj["data"].(map[string]any)
+		if data == nil || data["ingress-class"] != wantIngressClass {
+			t.Errorf("config-network data[ingress-class] = %v, want %q", data["ingress-class"], wantIngressClass)
+		}
+	}
+	if !found {
+		t.Fatalf("dist/install.yaml: config-network ConfigMap not found in rendered bundle")
+	}
+}


### PR DESCRIPTION
Closes #45 (A6-1).

Codifies the Kourier **ingress-class** declaratively so the OKE fix ships in the install bundle instead of being a hand-run `kubectl patch`. (The earlier "Kourier broken on k8s 1.34" diagnosis was wrong — the real cause was the ingress-class being unset/misconfigured.)

**Mechanism — Option (c): an operator-managed `config-network` ConfigMap in the install bundle.** Chosen over (a) a `KnativeServing` CR (would pull in the whole Knative Operator — the repo uses raw serving-core everywhere) and (b) a Go reconciler (needs foreign-namespace ConfigMap RBAC for marginal benefit). ADR-0001-compliant: bundle-owned + declarative, not an out-of-band tweak. Trade-off (apply-time set, no active drift-correction) and the upgrade path to a reconciler are recorded in **ADR-0009**.

**The config:** `config/knative/config-network.yaml` — ConfigMap `config-network` in `namespace: knative-serving`, `data.ingress-class: kourier.ingress.networking.knative.dev` (full controller-qualified form).

**Namespace immunity:** the bundle's top-level `namespace: kn-next-operator-system` + `namePrefix` would rewrite it; a builtin `PatchTransformer` (`config_network_repin.yaml`, runs after the built-in transformers) re-pins name+namespace. Proven: `kustomize build config/default | grep -A1 'name: config-network'` → `namespace: knative-serving`.

**Tests (pure-Go, no cluster — mirrors `internal/install/*_test.go`):** `TestConfigNetworkManifestSetsKourierIngressClass` (RED-first: asserts the manifest's kind/name/namespace/ingress-class) and `TestInstallBundleCarriesKourierIngressClass` (skip-if-not-generated: decodes `dist/install.yaml` and asserts the config-network ConfigMap survived the kustomize wiring in `knative-serving`). Live ingress behavior stays in the heavy `test/e2e` harness.

**RBAC/codegen: none** (static bundle ConfigMap, no API types) — `make manifests generate` produces no diff.

**Docs:** ADR-0009; operator README (kourier prereq + recommend `kubectl apply --server-side` so the partial ConfigMap merges); `docs/MATURITY_PLAN.md` root-cause correction; fixed `kourier.knative.dev` short-form drift in the knative skill.

**Honest caveat (flagged in ADR-0009, not silently fixed):** the local/e2e harness installs **net-istio**, not net-kourier — so this kourier ingress-class is kourier-only; aligning the harness is a tracked follow-up.

**Verified:** `go test ./internal/install/...` GREEN · `go build ./...` clean · `make manifests generate` no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
