### PR TITLE
Operator: ship Knative PVC feature flags (config-features) for the bytecode-cache ksvc (#59)

### DIFF
--- a/docs/MATURITY_PLAN.md
+++ b/docs/MATURITY_PLAN.md
@@ -33,6 +33,13 @@
   Now codified declaratively: the operator install bundle ships a `config-network` ConfigMap
   setting `ingress-class: kourier.ingress.networking.knative.dev` (issue #45, ADR-0009),
   replacing the manual `kubectl patch`.
+- **Bytecode-cache PVC feature flags** — the bytecode-cache ksvc mounts a writable PVC, which
+  Knative Serving gates behind two default-off `config-features` flags
+  (`kubernetes.podspec-persistent-volume-claim` + `...-write`); without them the admission webhook
+  denies the ksvc. Previously a manual cluster step; now **bundle-owned**: the operator install
+  bundle ships a `config-features` ConfigMap enabling both flags (issue #59, ADR-0010). These flags
+  are networking-layer-independent (safe under net-istio and kourier); a StorageClass/provisioner
+  is still a separate prerequisite (kind ships `local-path`).
 
 ## Phases (sequential; each gated by exit criteria)
 

--- a/docs/adr/0010-knative-pvc-feature-flags.md
+++ b/docs/adr/0010-knative-pvc-feature-flags.md
@@ -1,0 +1,88 @@
+# ADR-0010: Operator-managed Knative PVC feature flags via a declarative bundle ConfigMap
+
+- Status: Accepted
+- Date: 2026-06-22
+- Deciders: knext architect
+- Related: ADR-0001 (operator = single source of truth), ADR-0009 (Kourier ingress-class — same
+  bundle pattern), issue #59 (PVC feature flags for the bytecode-cache ksvc),
+  `docs/MATURITY_PLAN.md` (Tier-A correctness)
+
+## Context
+
+The bytecode-cache ksvc (emitted by the operator when `spec.enableBytecodeCache` is set) mounts a
+**PersistentVolumeClaim** so the runtime can persist its `NODE_COMPILE_CACHE` across cold starts.
+Knative Serving gates PVC-referencing PodSpecs behind two feature flags in the `config-features`
+ConfigMap (namespace `knative-serving`), both **default-off**:
+
+- `kubernetes.podspec-persistent-volume-claim` — allow a PVC volume at all.
+- `kubernetes.podspec-persistent-volume-write` — allow a **writable** (non-`readOnly`) PVC mount.
+  Required here because the cache mount must be writable.
+
+The stage-4 kind integration test found that with these flags off, Knative's admission webhook
+**denies** the ksvc and reconcile fails with no ksvc created. OKE already had the flags enabled
+(the bytecode feature was validated live there), so the gap was a missing **install prerequisite**,
+not a reconciler bug. Setting the flags by hand (`kubectl patch cm/config-features ...`) is the same
+out-of-band, easy-to-forget mutation ADR-0009 eliminated for the ingress-class. We want them set
+**declaratively** as part of the operator's installable bundle: one `kubectl apply` of `install.yaml`
+yields a cluster where the bytecode-cache ksvc admits cleanly, no manual follow-up.
+
+## Decision
+
+1. **Ship a declarative `config-features` ConfigMap in the install bundle.**
+   `config/knative/config-features.yaml` defines a `ConfigMap` named `config-features` in the
+   `knative-serving` namespace with both PVC flags = `enabled`. It is wired into the bundle via
+   `config/knative/kustomization.yaml` → `config/default` (`- ../knative`, already present).
+2. **Apply with `kubectl apply --server-side`** so it **merges** into the `config-features` Knative
+   Serving already owns (it holds many other feature keys) rather than clobbering it.
+3. **Namespace/name immunity.** `config/default` applies `namespace: kn-next-operator-system` and
+   `namePrefix: kn-next-operator-` to every resource, which would rewrite this ConfigMap to
+   `kn-next-operator-config-features` in `kn-next-operator-system` — where Serving never reads it. A
+   **separate** `transformers:` entry (`config/default/config_features_repin.yaml`, a builtin
+   `PatchTransformer`) runs **after** the namespace/namePrefix transformers and re-pins both name
+   (`config-features`) and namespace (`knative-serving`). A separate transformer is required because
+   the existing `config_network_repin.yaml` targets `.*config-network`, which does **not** match
+   `config-features`; we do not broaden that regex.
+
+## Networking-layer independence (vs ADR-0009)
+
+Unlike the ingress-class ConfigMap (#45 / ADR-0009), which is **kourier-only** and inert/wrong on an
+istio cluster, the PVC feature flags are **networking-layer-independent**: they govern PodSpec
+admission, not route programming. They are therefore safe and correct under **both** net-istio and
+kourier, including the operator's istio-based local kind/e2e harness. There is no harness mismatch to
+flag.
+
+A `StorageClass` / volume provisioner is still a **separate cluster prerequisite** (a PVC needs
+something to bind to). kind ships the `local-path` provisioner by default, so the bundle's flags plus
+kind's default storage are sufficient for the integration test; production clusters must supply their
+own StorageClass.
+
+## Options considered
+
+| Option | What | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| (a) `KnativeServing` CR | Set feature flags via the Knative Operator CR | Canonical Knative config surface | Pulls in the **whole Knative Operator**; the repo uses raw `serving-core` everywhere — a large, unwanted dependency | Rejected |
+| (b) Go reconciler | A controller that writes `config-features` in `knative-serving` | Self-healing; drift correction | Needs **foreign-namespace ConfigMap RBAC**; runtime complexity for a one-shot config | Rejected (now) |
+| (c) Declarative bundle ConfigMap | Ship `config-features` in `install.yaml` | Bundle-owned + declarative (ADR-0001-compliant); zero new RBAC, no API types, no runtime read/write; single `apply`; identical to the proven ADR-0009 pattern | One-shot — does not self-heal if a human later disables the flags | **Chosen** |
+
+## Consequences
+
+- The manual `kubectl patch cm/config-features` step is gone; `kubectl apply --server-side` of
+  `install.yaml` enables the PVC flags so the bytecode-cache ksvc admits cleanly.
+- No new RBAC, no new API types, no reconciler change. `make manifests` / `make generate` produce no
+  diff; the operator already builds the PVC-mounting ksvc — this only supplies the cluster prereq.
+- **Drift correction, not self-healing:** if an operator later disables a flag, the bundle does not
+  re-assert it until the next `apply`. **Upgrade path:** promote to option (b) — a small reconciler
+  with scoped `knative-serving` ConfigMap RBAC — if drift becomes a real operational problem. The
+  declarative ConfigMap is forward-compatible with that.
+- **StorageClass remains out of scope:** binding a PVC requires a provisioner. kind's default
+  `local-path` covers CI; production clusters supply their own. This ADR only removes the
+  feature-flag gate.
+
+## Action items
+
+- [x] `config/knative/config-features.yaml` + wire into `config/knative/kustomization.yaml`.
+- [x] `config/default/config_features_repin.yaml` post-transform repin + wire into
+      `config/default/kustomization.yaml`.
+- [x] Tests: source-manifest assertion + rendered-bundle namespace-immunity assertion.
+- [x] Docs: operator README prerequisite (`--server-side`, prereq for `enableBytecodeCache`);
+      `docs/MATURITY_PLAN.md`.

--- a/packages/kn-next-operator/README.md
+++ b/packages/kn-next-operator/README.md
@@ -12,7 +12,9 @@ cosign-signed, and pushed to `ghcr.io/getknext-dev/kn-next-operator` by
 [`.github/workflows/operator-supply-chain.yml`](../../.github/workflows/operator-supply-chain.yml).
 Each `main` build also publishes a digest-pinned `install.yaml` bundle (CRDs + RBAC +
 manager Deployment + webhook + cert-manager resources + the Knative `config-network`
-ConfigMap that sets the Kourier ingress-class — issue #45 / ADR-0009).
+ConfigMap that sets the Kourier ingress-class — issue #45 / ADR-0009 — and the
+`config-features` ConfigMap that enables the PVC PodSpec flags for the bytecode-cache
+ksvc — issue #59 / ADR-0010).
 
 Install knext's control plane with a single apply:
 
@@ -20,9 +22,9 @@ Install knext's control plane with a single apply:
 kubectl apply --server-side -f https://github.com/getknext-dev/knext/releases/latest/download/install.yaml
 ```
 
-> Use `--server-side` so the bundle's `config-network` ConfigMap **merges** into the
-> one Knative Serving already owns (which holds other networking keys) instead of
-> clobbering it.
+> Use `--server-side` so the bundle's `config-network` **and** `config-features`
+> ConfigMaps **merge** into the ones Knative Serving already owns (which hold other
+> networking / feature keys) instead of clobbering them.
 >
 > The bundle's manager image is **digest-pinned** (`@sha256:…`); it never uses
 > `:latest` (enforced by `hack/check-no-latest.sh`).
@@ -36,6 +38,15 @@ kubectl apply --server-side -f https://github.com/getknext-dev/knext/releases/la
 >   controller-qualified form. Without it, Serving leaves the ingress-class unset and
 >   never wires routes to Kourier (this was the real cause of the OKE "Kourier broken
 >   on k8s 1.34" symptom — see ADR-0009).
+> - **PVC feature flags** (prerequisite for `spec.enableBytecodeCache`): the bundle
+>   ships a `config-features` ConfigMap (`namespace: knative-serving`) enabling
+>   `kubernetes.podspec-persistent-volume-claim` and
+>   `kubernetes.podspec-persistent-volume-write` (both default-off). The bytecode-cache
+>   ksvc mounts a **writable** PVC; without both flags Knative's admission webhook
+>   denies the ksvc and reconcile fails — see ADR-0010. Unlike the ingress-class, these
+>   flags are networking-layer-independent (safe under net-istio and kourier). A
+>   `StorageClass`/provisioner is still required to bind the PVC (kind ships
+>   `local-path`).
 
 ### Verify the signature (optional)
 

--- a/packages/kn-next-operator/config/default/config_features_repin.yaml
+++ b/packages/kn-next-operator/config/default/config_features_repin.yaml
@@ -1,0 +1,29 @@
+# issue #59: namespace/name immunity for the operator-managed config-features ConfigMap.
+#
+# config/default applies `namespace: kn-next-operator-system` and
+# `namePrefix: kn-next-operator-` to EVERY resource. That would rewrite this
+# ConfigMap to `kn-next-operator-config-features` in `kn-next-operator-system`, where
+# Knative Serving would never read it. Knative Serving requires the ConfigMap to be
+# exactly `config-features` in the `knative-serving` namespace.
+#
+# A `transformers:` entry runs AFTER the built-in namespace + namePrefix transformers,
+# so this PatchTransformer can put both fields back. The target regex matches the
+# prefixed name.
+#
+# NOTE: a SEPARATE transformer is required — the existing config_network_repin.yaml
+# targets `.*config-network`, which does NOT match `config-features`. Do not broaden
+# that regex; each operator-managed Knative ConfigMap gets its own re-pin.
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: config-features-repin
+patch: |-
+  - op: replace
+    path: /metadata/name
+    value: config-features
+  - op: replace
+    path: /metadata/namespace
+    value: knative-serving
+target:
+  kind: ConfigMap
+  name: .*config-features

--- a/packages/kn-next-operator/config/default/kustomization.yaml
+++ b/packages/kn-next-operator/config/default/kustomization.yaml
@@ -39,9 +39,13 @@ resources:
 #- ../network-policy
 
 # [KNATIVE] Runs after the built-in namespace/namePrefix transformers to re-pin the
-# config-network ConfigMap to its required name + namespace (issue #45).
+# operator-managed Knative ConfigMaps to their required name + namespace:
+#   - config-network  (issue #45)
+#   - config-features (issue #59) — needs its own transformer; the config-network
+#     target regex (.*config-network) does not match config-features.
 transformers:
 - config_network_repin.yaml
+- config_features_repin.yaml
 
 # Uncomment the patches line if you enable Metrics
 patches:

--- a/packages/kn-next-operator/config/knative/config-features.yaml
+++ b/packages/kn-next-operator/config/knative/config-features.yaml
@@ -1,0 +1,29 @@
+# config-features: operator-managed Knative Serving feature flags (issue #59).
+#
+# The bytecode-cache ksvc (enabled via spec.enableBytecodeCache) mounts a PVC with a
+# WRITABLE mount so the runtime can persist its NODE_COMPILE_CACHE across cold starts.
+# Knative Serving gates PVC-referencing PodSpecs behind two feature flags that are
+# DEFAULT-OFF; without both enabled the admission webhook DENIES the ksvc and reconcile
+# fails with no ksvc created (found by the stage-4 kind integration test).
+#
+#   - kubernetes.podspec-persistent-volume-claim: allow a PVC volume at all.
+#   - kubernetes.podspec-persistent-volume-write : allow a writable (non-readOnly)
+#     PVC mount. Required because the cache mount must be writable.
+#
+# These flags are networking-layer-independent, so this is safe under BOTH net-istio
+# and kourier (unlike the config-network ingress-class fix in #45). A StorageClass /
+# provisioner is still a separate cluster prerequisite (kind ships local-path).
+#
+# Apply with `kubectl apply --server-side` so this merges into any existing
+# config-features owned by the Knative Serving install (it owns other keys).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: features
+data:
+  kubernetes.podspec-persistent-volume-claim: enabled
+  kubernetes.podspec-persistent-volume-write: enabled

--- a/packages/kn-next-operator/config/knative/kustomization.yaml
+++ b/packages/kn-next-operator/config/knative/kustomization.yaml
@@ -1,11 +1,14 @@
-# Operator-managed Knative network config (issue #45): the declarative
-# config-network ConfigMap that sets the Kourier ingress-class.
+# Operator-managed Knative config (issues #45, #59): declarative ConfigMaps for
+# Knative Serving:
+#   - config-network  : Kourier ingress-class (#45).
+#   - config-features : PVC PodSpec feature flags for the bytecode-cache ksvc (#59).
 #
-# This is pinned to the knative-serving namespace. When included from
+# Both are pinned to the knative-serving namespace. When included from
 # config/default (which applies `namespace: kn-next-operator-system` to all
-# resources), that namespace would be rewritten — so config/default re-pins this
-# ConfigMap back to `config-network` / `knative-serving` with a PatchTransformer
-# (config_network_repin.yaml) that runs AFTER the namespace/namePrefix transformers.
+# resources), that namespace would be rewritten — so config/default re-pins each
+# ConfigMap back to its required name / `knative-serving` with a PatchTransformer
+# (config_network_repin.yaml, config_features_repin.yaml) that runs AFTER the
+# namespace/namePrefix transformers.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -13,3 +16,4 @@ namespace: knative-serving
 
 resources:
 - config-network.yaml
+- config-features.yaml

--- a/packages/kn-next-operator/internal/install/pvc_feature_flags_test.go
+++ b/packages/kn-next-operator/internal/install/pvc_feature_flags_test.go
@@ -1,0 +1,106 @@
+// Package install also verifies the operator-managed Knative PVC feature flags
+// (issue #59): the install bundle ships a declarative `config-features` ConfigMap in
+// the knative-serving namespace that enables BOTH the persistent-volume-claim and
+// persistent-volume-write PodSpec feature flags. These are default-off in Knative
+// Serving and gate the bytecode-cache ksvc (which mounts a WRITABLE PVC) — without
+// them the admission webhook denies the ksvc and reconcile fails. Like config-network
+// (#45), this ConfigMap is immune to the bundle's namespace transformer.
+package install
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	wantConfigFeaturesName = "config-features"
+	pvcClaimFlag           = "kubernetes.podspec-persistent-volume-claim"
+	pvcWriteFlag           = "kubernetes.podspec-persistent-volume-write"
+	wantFlagValue          = "enabled"
+)
+
+// TestConfigFeaturesManifestEnablesPVCFlags asserts the source manifest
+// config/knative/config-features.yaml is a ConfigMap named config-features in the
+// knative-serving namespace with both PVC feature flags enabled.
+func TestConfigFeaturesManifestEnablesPVCFlags(t *testing.T) {
+	raw := repoFile(t, "config/knative/config-features.yaml")
+
+	var obj struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("decoding config-features.yaml: %v", err)
+	}
+
+	if obj.Kind != "ConfigMap" {
+		t.Errorf("kind = %q, want ConfigMap", obj.Kind)
+	}
+	if obj.Metadata.Name != wantConfigFeaturesName {
+		t.Errorf("metadata.name = %q, want %q", obj.Metadata.Name, wantConfigFeaturesName)
+	}
+	if obj.Metadata.Namespace != wantKnativeNamespace {
+		t.Errorf("metadata.namespace = %q, want %q", obj.Metadata.Namespace, wantKnativeNamespace)
+	}
+	if got := obj.Data[pvcClaimFlag]; got != wantFlagValue {
+		t.Errorf("data[%s] = %q, want %q", pvcClaimFlag, got, wantFlagValue)
+	}
+	if got := obj.Data[pvcWriteFlag]; got != wantFlagValue {
+		t.Errorf("data[%s] = %q, want %q", pvcWriteFlag, got, wantFlagValue)
+	}
+}
+
+// TestInstallBundleEnablesPVCFlags proves the kustomize wiring + namespace immunity:
+// the rendered dist/install.yaml must contain the config-features ConfigMap STILL in
+// knative-serving (not rewritten to the operator namespace by the top-level namespace
+// transformer) with both PVC feature flags enabled. Skip cleanly when the bundle has
+// not been generated (run `make build-installer`).
+func TestInstallBundleEnablesPVCFlags(t *testing.T) {
+	if _, err := os.Stat(filepath.Join("..", "..", "dist", "install.yaml")); err != nil {
+		t.Skip("dist/install.yaml not generated (run `make build-installer`)")
+	}
+	raw := repoFile(t, "dist/install.yaml")
+	dec := yaml.NewDecoder(strings.NewReader(raw))
+
+	found := false
+	for {
+		var obj map[string]any
+		if err := dec.Decode(&obj); err != nil {
+			break
+		}
+		if len(obj) == 0 {
+			continue
+		}
+		if obj["kind"] != "ConfigMap" {
+			continue
+		}
+		meta, _ := obj["metadata"].(map[string]any)
+		if meta == nil || meta["name"] != wantConfigFeaturesName {
+			continue
+		}
+		found = true
+		if meta["namespace"] != wantKnativeNamespace {
+			t.Errorf("config-features namespace = %v, want %q (namespace transformer must not rewrite it)",
+				meta["namespace"], wantKnativeNamespace)
+		}
+		data, _ := obj["data"].(map[string]any)
+		if data == nil || data[pvcClaimFlag] != wantFlagValue {
+			t.Errorf("config-features data[%s] = %v, want %q", pvcClaimFlag, data[pvcClaimFlag], wantFlagValue)
+		}
+		if data == nil || data[pvcWriteFlag] != wantFlagValue {
+			t.Errorf("config-features data[%s] = %v, want %q", pvcWriteFlag, data[pvcWriteFlag], wantFlagValue)
+		}
+	}
+	if !found {
+		t.Fatalf("dist/install.yaml: config-features ConfigMap not found in rendered bundle")
+	}
+}


### PR DESCRIPTION
Closes #59.

The bytecode-cache ksvc mounts a PVC with a **writable** mount, which Knative's admission webhook rejects unless `config-features` (ns `knative-serving`) enables both `kubernetes.podspec-persistent-volume-claim` AND `kubernetes.podspec-persistent-volume-write` (default off). This was a manual cluster prerequisite; now it's codified declaratively in the install bundle — same operator-managed, bundle-owned pattern as the Kourier ingress-class (#45 / ADR-0009). **Bundle-only change; no reconciler change** (the operator already builds the PVC-mounting ksvc — this supplies the missing prerequisite).

**Manifest:** `config/knative/config-features.yaml` — ConfigMap `config-features` in `knative-serving`, both PVC feature flags `enabled`. Applied with `kubectl apply --server-side` so it merges into Serving's existing `config-features` rather than clobbering it.

**Namespace immunity:** a **second** kustomize `PatchTransformer` (`config_features_repin.yaml`, targeting `.*config-features`) re-pins name+namespace after the bundle's `namespace:`/`namePrefix:` transforms. The existing `.*config-network` transformer doesn't match config-features, so a separate transformer is used (the regex was deliberately NOT broadened). Proven: `kustomize build config/default` renders **both** `config-features` and `config-network` at `namespace: knative-serving`.

**Tests (pure-Go, RED→GREEN):** `internal/install/pvc_feature_flags_test.go` — `TestConfigFeaturesManifestEnablesPVCFlags` (manifest kind/name/namespace/both-flags) + `TestInstallBundleEnablesPVCFlags` (rendered `dist/install.yaml` carries it in `knative-serving`, proving the transformer survived). The #45 config-network tests still pass (no regression).

**RBAC/codegen: none** — `make manifests generate` produces no diff.

**Docs:** ADR-0010 (declarative bundle ConfigMap chosen over a KnativeServing CR / Go reconciler; PVC flags are networking-layer-independent so safe under both net-istio and kourier, unlike #45; the write flag is required because the mount is writable; a StorageClass/provisioner is still a separate prereq — kind ships local-path). README + MATURITY_PLAN updated.

**Verified:** `go test ./internal/install/...` GREEN (incl. #45 regression) · `go build ./...` clean · `make manifests generate` no diff · `check-no-latest.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
