### PR TITLE
Docs: evidence-gated Next.js compatibility matrix (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ flowchart LR
 - ✅ **Monorepo Ready** – Turborepo for efficient builds
 - ✅ **Kubernetes Operator** – Declarative `NextApp` CRD for GitOps-style deployment
 
+> **What Next.js features does knext support?** See the evidence-gated
+> [compatibility matrix](docs/compat-matrix.md) — every ✅ is backed by the per-PR `compat-smoke`
+> gate or test-covered source, and a guard test fails CI on any overclaim. (knext does **not** yet
+> pass the official Next.js compatibility suite; that is tracked separately.)
+
 ---
 
 ## Performance Benchmarks

--- a/docs/adr/0007-compat-suite.md
+++ b/docs/adr/0007-compat-suite.md
@@ -208,6 +208,11 @@ Port the reference workflow with knext substitutions:
   - [ ] Add `.github/workflows/test-e2e-deploy.yml` (port of the reference; **pinned** Next ref;
         16-way shard; `schedule` + `workflow_dispatch`).
   - [ ] Align in-repo `next` version with the pinned harness ref (16.2.x).
+- **A3-2 (publish the matrix, done):**
+  - [x] Publish `docs/compat-matrix.md` — an honest, evidence-gated supported/unsupported matrix,
+        linked from the README, with a guard test (`tests/compat-matrix.test.ts`) that fails CI on
+        any overclaim (issue #41). Note: the matrix is gated on the per-PR `compat-smoke` checks; it
+        is **not** the official suite (#89) and says so explicitly.
 - **A3-3 (close the loop on the claim):**
   - [ ] Track the exclude-list shrinking to zero as the public "verified-adapter" scoreboard; surface
         it in docs.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -1,0 +1,60 @@
+# knext — Next.js compatibility matrix
+
+> **Honest, evidence-gated status of what the knext adapter supports.** Every row is grounded in
+> real, on-disk evidence and a mechanical guard test (`tests/compat-matrix.test.ts`) fails CI if a
+> ✅ ("supported") row cannot be backed up. When in doubt we mark ⚠️, not ✅.
+>
+> **This is NOT a claim that knext passes the official Next.js compatibility suite.** That suite
+> (the `vercel/next.js` deploy-test harness, ADR-0007 option B) is **not wired yet** — tracked in
+> [issue #89](https://github.com/AhmedElBanna80/knext/issues/89). Until #89 is green nightly, no row
+> here may say "official suite ✅". See **Maintenance & honesty** below.
+
+## Legend
+
+| Marker | Meaning |
+|---|---|
+| ✅ | **Supported** — backed by a red-on-fail check (the per-PR `compat-smoke` gate) or test-covered source on disk. |
+| ⚠️ | **Partial** — implemented but **not** guarded by a hard correctness check, or with a known caveat (see Notes). Do not rely on it as "verified." |
+| ❌ | **Unsupported / unverified** — no working implementation or no evidence; treat as a gap. |
+| ⛔ | **Upstream-gated** — architecturally out of reach today (global edge, not yet adapter-standardizable upstream). |
+
+The **Evidence** column cites either a real file path in this repo, or a `compat-smoke` check id
+(`a`–`g`) from [`apps/file-manager/scripts/compat-smoke.mjs`](../apps/file-manager/scripts/compat-smoke.mjs),
+or the `compat-smoke` CI job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). The
+`compat-smoke` job runs per-PR on a **Node + Bun** matrix (ADR-0007 / A3-1). It is a knext **smoke**
+gate, not the official suite.
+
+## Matrix
+
+| Feature | Status | Evidence | Notes |
+|---|---|---|---|
+| App Router (RSC server render, `GET /` → 200 HTML) | ✅ | smoke a | Hard-asserts 200 + `text/html` + non-trivial body against the standalone `server.js`. |
+| RSC flight payload (`RSC: 1` → `text/x-component`) | ✅ | smoke b | Hard-asserts the React flight content-type. |
+| Route handlers (App Router `app/api/*/route.ts`) | ✅ | smoke c, apps/file-manager/src/app/api/health/route.ts | Hard-asserts `GET /api/health` → 200 + valid JSON. |
+| Dynamic routes (`force-dynamic`, per-request render) | ✅ | smoke d | Hard-asserts 200 on a `force-dynamic` route. |
+| Static / prerendered routes (`force-static`) | ✅ | smoke e | Hard-asserts 200 on a `force-static` route. |
+| Middleware (Node runtime, response header injection) | ✅ | smoke f, apps/file-manager/src/middleware.ts | Hard-asserts the middleware-injected `x-knext-smoke: 1` header. Node-runtime middleware only (see edge-middleware row). |
+| Graceful shutdown (SIGTERM drain) | ✅ | packages/kn-next/src/adapters/shutdown.ts, packages/kn-next/src/__tests__/shutdown.test.ts | Unit-tested drain-on-SIGTERM in the standalone runtime. Not yet exercised end-to-end by `compat-smoke` (no SIGTERM-drain HTTP check in the as-built script). |
+| ISR / Data Cache (Redis-backed cache handler) | ⚠️ | apps/file-manager/cache-handler.js, apps/file-manager/next.config.ts | Redis cache handler (`cacheHandler` in `next.config.ts`), **not** GCS. `compat-smoke` runs with `REDIS_URL=""` (in-memory fallback) and has **no revalidate/ISR-freshness assertion**, so ISR correctness is unverified by the gate. |
+| `next/image` optimization (sharp, avif/webp) | ⚠️ | docs/adr/0006-image-optimization.md, apps/file-manager/next.config.ts, packages/kn-next/src/adapters/image-cache-sync.ts | Implementation landed (ADR-0006, sharp #43, scale-to-zero image cache sync #66). But `compat-smoke` check **(g) is skip-on-fail**, not a hard gate — a missing/failed optimizer downgrades to SKIP, so the matrix does not mark this ✅. |
+| Server Actions (`'use server'` mutations) | ⚠️ | apps/file-manager/src/app/actions.ts | Server Actions exist in the app, but there is **no** `compat-smoke` or unit assertion exercising a Server Action round-trip. Configured, not verified. |
+| Streaming / Suspense (incremental flush) | ❌ | — | No streaming/Suspense flush assertion in `compat-smoke` and no other evidence. Listed as a planned check in ADR-0007 but not built. |
+| Edge Middleware (edge runtime) | ⛔ | docs/adr/0007-compat-suite.md | Upstream-gated: edge-runtime middleware is not yet adapter-standardizable on Knative; knext middleware runs on the Node runtime only. |
+| PPR / Cache Components | ⛔ | docs/adr/0007-compat-suite.md | Upstream-gated: Partial Prerendering / Cache Components are not yet adapter-standardizable (CLAUDE.md §6, Tier C). |
+| Official Next.js compatibility suite | ❌ | docs/adr/0007-compat-suite.md | The `vercel/next.js` deploy-test harness (ADR-0007 option B / A3-2) is **not wired** — [issue #89](https://github.com/AhmedElBanna80/knext/issues/89) is open. No row may claim official ✅ until #89 is green nightly. |
+
+## Maintenance & honesty
+
+- **Every ✅ is mechanically gated.** `tests/compat-matrix.test.ts` parses this table and fails if a
+  ✅ row's Evidence does not resolve to a real on-disk file, a **hard** `compat-smoke` check id, or
+  the `compat-smoke` CI job. It also forbids: marking the **official suite** ✅ while #89 is open,
+  and citing the **skip-on-fail** `next/image` check (g) as proof of a ✅.
+- **The `compat-smoke` caveats are load-bearing.** It runs with `REDIS_URL=""` (in-memory cache, not
+  Redis) and treats `next/image` (check g) as **skip-on-fail**. That is exactly why ISR and image
+  optimization are ⚠️, not ✅, even though both are implemented.
+- **Promotion path to ✅ for the partials / gaps.** A ⚠️/❌ row may move to ✅ only when a **red-on-fail**
+  check covers it — e.g. an ISR-revalidate assertion (with a real `REDIS_URL`), a hard (non-skip)
+  `next/image` assertion, a streaming-flush assertion, or the official suite landing via #89.
+- **The official-suite claim is owned by #89.** Only after the full `vercel/next.js` deploy-test
+  harness is green nightly (ADR-0007, A3-2/A3-3) may any doc say knext "passes the official Next.js
+  adapter compatibility suite." This matrix is a smoke-gated honesty ledger in the meantime.

--- a/tests/compat-matrix.test.ts
+++ b/tests/compat-matrix.test.ts
@@ -1,0 +1,178 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * GUARD TEST for docs/compat-matrix.md (issue #41 / A3-2).
+ *
+ * This test mechanically prevents OVERCLAIMING in the compatibility matrix. Every ✅
+ * ("supported") row must be backed by REAL, on-disk evidence:
+ *   - a file path that exists in the repo, OR
+ *   - a compat-smoke check id (a–g) that actually exists in compat-smoke.mjs, OR
+ *   - the `compat-smoke` CI job in .github/workflows/ci.yml.
+ *
+ * It also enforces the project honesty rules:
+ *   - No ✅ row may rely on the `next/image` SKIP check (g) — that check is skip-on-fail.
+ *   - No row may claim the "official" compat suite is ✅ while issue #89 is still open.
+ *   - Every Status cell uses exactly one of the 4 legal markers (✅ ⚠️ ❌ ⛔).
+ */
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const MATRIX_PATH = resolve(REPO_ROOT, 'docs/compat-matrix.md');
+const SMOKE_PATH = resolve(REPO_ROOT, 'apps/file-manager/scripts/compat-smoke.mjs');
+const CI_PATH = resolve(REPO_ROOT, '.github/workflows/ci.yml');
+
+const LEGAL_MARKERS = ['✅', '⚠️', '❌', '⛔'];
+
+interface MatrixRow {
+  feature: string;
+  status: string;
+  evidence: string;
+  notes: string;
+}
+
+/** Parse the first Markdown pipe-table in the matrix doc into rows. */
+function parseMatrix(md: string): MatrixRow[] {
+  const lines = md.split('\n');
+  const rows: MatrixRow[] = [];
+  let inTable = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) {
+      if (inTable) break; // table ended
+      continue;
+    }
+    const cells = trimmed
+      .slice(1, trimmed.endsWith('|') ? -1 : undefined)
+      .split('|')
+      .map((c) => c.trim());
+    // Header row
+    if (!inTable) {
+      const header = cells.map((c) => c.toLowerCase());
+      if (header[0]?.includes('feature') && header.some((c) => c.includes('status'))) {
+        inTable = true;
+      }
+      continue;
+    }
+    // Separator row (---|---)
+    if (cells.every((c) => /^:?-+:?$/.test(c))) continue;
+    const [feature, status, evidence, notes] = cells;
+    rows.push({
+      feature: feature ?? '',
+      status: status ?? '',
+      evidence: evidence ?? '',
+      notes: notes ?? '',
+    });
+  }
+  return rows;
+}
+
+/**
+ * The compat-smoke check ids that are HARD (red-on-fail).
+ *
+ * A check is declared as `await check('a. ...', async () => { ... })`. A check is HARD
+ * only if its body does NOT call `skip(...)` — `next/image` (g) calls skip() and is
+ * therefore skip-on-fail, NOT a hard gate, so it must be excluded.
+ */
+function hardSmokeCheckIds(smokeSrc: string): Set<string> {
+  const ids = new Set<string>();
+  // Match each `check('<id>. <title>', ...` and the body up to the next `await check(` or `// ──`.
+  const re = /check\(\s*['"]([a-g])\.[\s\S]*?(?=await check\(|\/\/ ─{2,}|printReport\()/g;
+  let m: RegExpExecArray | null;
+  m = re.exec(smokeSrc);
+  while (m !== null) {
+    const id = m[1];
+    const body = m[0];
+    // skip-on-fail checks call `skip(...)` to downgrade a failure; they are NOT hard gates.
+    if (!/\bskip\(/.test(body)) ids.add(id);
+    m = re.exec(smokeSrc);
+  }
+  return ids;
+}
+
+/** Resolve an Evidence cell to a list of citation tokens (paths, check ids, ci-job refs). */
+function citations(evidence: string): string[] {
+  // strip Markdown code/link wrappers, split on commas / semicolons / "and"
+  return evidence
+    .replace(/`/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .split(/[,;]|\band\b/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+describe('docs/compat-matrix.md — honesty guard (issue #41)', () => {
+  it('the matrix file exists', () => {
+    expect(existsSync(MATRIX_PATH)).toBe(true);
+  });
+
+  const md = existsSync(MATRIX_PATH) ? readFileSync(MATRIX_PATH, 'utf8') : '';
+  const smokeSrc = readFileSync(SMOKE_PATH, 'utf8');
+  const ciSrc = readFileSync(CI_PATH, 'utf8');
+  const rows = parseMatrix(md);
+  const hardIds = hardSmokeCheckIds(smokeSrc);
+  const hasComptSmokeJob = /^\s*compat-smoke:/m.test(ciSrc);
+
+  it('has a non-trivial table with the expected columns', () => {
+    expect(rows.length).toBeGreaterThanOrEqual(8);
+    expect(md.toLowerCase()).toContain('| feature');
+    expect(md.toLowerCase()).toContain('evidence');
+  });
+
+  it('every Status cell uses exactly one legal marker (✅ ⚠️ ❌ ⛔)', () => {
+    for (const row of rows) {
+      const markers = LEGAL_MARKERS.filter((mk) => row.status.includes(mk));
+      expect(markers.length, `bad status for "${row.feature}": "${row.status}"`).toBe(1);
+    }
+  });
+
+  it('every ✅ row cites real on-disk evidence or a hard smoke/ci reference', () => {
+    const supported = rows.filter((r) => r.status.includes('✅'));
+    // sanity: there should be some supported features
+    expect(supported.length).toBeGreaterThan(0);
+
+    for (const row of supported) {
+      const cites = citations(row.evidence);
+      expect(cites.length, `✅ row "${row.feature}" has no evidence`).toBeGreaterThan(0);
+
+      const ok = cites.some((cite) => {
+        // (1) compat-smoke check id like "smoke a" / "(a)" / "check a"
+        const idMatch = cite.match(/(?:smoke|check)?\s*\(?([a-g])\)?$/i);
+        if (idMatch && hardIds.has(idMatch[1].toLowerCase())) return true;
+        // (2) the compat-smoke CI job
+        if (/compat-smoke/i.test(cite) && hasComptSmokeJob) return true;
+        // (3) an on-disk file path (allow a trailing :line or anchor)
+        const pathToken = cite.split(/[:\s#]/)[0];
+        if (pathToken.includes('/') && existsSync(resolve(REPO_ROOT, pathToken))) return true;
+        return false;
+      });
+
+      expect(ok, `✅ row "${row.feature}" evidence not verifiable: "${row.evidence}"`).toBe(true);
+    }
+  });
+
+  it('no ✅ row relies on the next/image SKIP check (g)', () => {
+    const supported = rows.filter((r) => r.status.includes('✅'));
+    for (const row of supported) {
+      const cites = citations(row.evidence);
+      const usesSkipCheck = cites.some((cite) => /(?:smoke|check)?\s*\(?g\)?$/i.test(cite.trim()));
+      expect(
+        usesSkipCheck,
+        `✅ row "${row.feature}" cites the skip-on-fail next/image check (g)`,
+      ).toBe(false);
+    }
+    // and (g) must indeed NOT be in the hard set, proving it is skip-on-fail
+    expect(hardIds.has('g')).toBe(false);
+  });
+
+  it('no row claims the official compat suite is ✅ while #89 is open', () => {
+    for (const row of rows) {
+      if (/official/i.test(row.feature) || /official/i.test(row.evidence)) {
+        expect(
+          row.status.includes('✅'),
+          `row "${row.feature}" claims official suite ✅ — not allowed (issue #89 open)`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/compat-matrix.test.ts
+++ b/tests/compat-matrix.test.ts
@@ -136,8 +136,10 @@ describe('docs/compat-matrix.md — honesty guard (issue #41)', () => {
       expect(cites.length, `✅ row "${row.feature}" has no evidence`).toBeGreaterThan(0);
 
       const ok = cites.some((cite) => {
-        // (1) compat-smoke check id like "smoke a" / "(a)" / "check a"
-        const idMatch = cite.match(/(?:smoke|check)?\s*\(?([a-g])\)?$/i);
+        // (1) compat-smoke check id like "smoke a" / "smoke (a)" / "check a".
+        // The `smoke`/`check` prefix is REQUIRED so a bare trailing letter on a file
+        // path (e.g. ".../a") can never be misread as a hard smoke-id citation.
+        const idMatch = cite.match(/(?:smoke|check)\s*\(?([a-g])\)?$/i);
         if (idMatch && hardIds.has(idMatch[1].toLowerCase())) return true;
         // (2) the compat-smoke CI job
         if (/compat-smoke/i.test(cite) && hasComptSmokeJob) return true;


### PR DESCRIPTION
Closes #41.

Publishes `docs/compat-matrix.md` — an **honest, evidence-gated** Next.js compatibility matrix — plus a vitest guard test that mechanically prevents overclaiming, and a README link. This is a credibility artifact (verified-adapter positioning), so every claim is checkable against the codebase.

**The matrix** (Feature | Status | Evidence | Notes), grounded in the merged A3-1 `compat-smoke` gate and real adapter code:
- ✅ **supported** (backed by a red-on-fail smoke check or unit test): App Router, RSC flight, route handlers, dynamic & static rendering, Node-runtime middleware, graceful shutdown.
- ⚠️ **partial** (works but evidence is weak/scope-limited): ISR/data cache (Redis, not GCS — and `compat-smoke` runs `REDIS_URL=""` with no revalidate assertion), `next/image` (sharp + object-store variant cache landed per #43/#66/ADR-0006, but the smoke `next/image` check is **skip-on-fail**, so not yet ✅), Server Actions (configured, no test).
- ❌ **unsupported**: streaming (no assertion), the official compatibility suite (**#89 is open** — no row may claim it passes).
- ⛔ **upstream-gated**: edge-runtime middleware, PPR/Cache Components.

**Anti-overclaim guard** (`tests/compat-matrix.test.ts`, runs in the existing vitest CI job): every ✅ row's Evidence must resolve to a real on-disk file OR a *hard* (red-on-fail) compat-smoke check id OR the `compat-smoke` CI job; the skip-on-fail `next/image` check (g) may NOT back a ✅; no row may mark the official suite ✅ while #89 is open; every status cell must use one of the four legal markers. This makes the matrix a *tested* artifact, not prose — it can't silently drift into overclaiming.

**Honesty caveats** are stated in a "Maintenance & honesty" section: the `REDIS_URL=""` smoke caveat, the `next/image` skip caveat, and that ⚠️ rows graduate to ✅ only when #89's official deploy-test suite confirms them.

**Verified:** guard test GREEN (full vitest suite 162 passed) · every ✅ evidence path resolves on disk · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
