### PR TITLE
Operator: fix reconcile hot-loop + status-write conflict spam (#98)

### DIFF
--- a/packages/kn-next-operator/internal/controller/nextapp_controller.go
+++ b/packages/kn-next-operator/internal/controller/nextapp_controller.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -33,9 +34,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
 	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/internal/validation"
@@ -126,6 +129,14 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, err
 	}
 
+	// Snapshot the OBSERVED status so the terminal status write can be skipped
+	// when the freshly-computed desired status is byte-identical (#98). Writing
+	// status on every pass re-triggers the For(&NextApp{}) watch → a ~45/s
+	// self-perpetuating reconcile hot-loop on an idle object. apimeta.
+	// SetStatusCondition preserves LastTransitionTime when a condition is
+	// unchanged, so this DeepEqual is stable for a converged, idle object.
+	observedStatus := nextApp.Status.DeepCopy()
+
 	// --- Finalizer: external-state teardown -------------------------------
 	// The finalizer pauses Kubernetes deletion until the operator clears the
 	// app's EXTERNAL state (object-store prefix + Redis keyspace) — state that
@@ -133,9 +144,14 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// In-cluster children (ksvc/SA/PVC) keep using ownerRef GC.
 	if nextApp.DeletionTimestamp.IsZero() {
 		// Live object: ensure the finalizer is present so we get a chance to
-		// run cleanup before the object is GC'd.
+		// run cleanup before the object is GC'd. Use a metadata Patch (not a
+		// full Update) so it does not race the later Status().Update: finalizers
+		// live in metadata, status in the /status subresource — patching one and
+		// updating the other touches disjoint resourceVersions and avoids the
+		// "object has been modified" conflict spam (#98).
+		patch := client.MergeFrom(nextApp.DeepCopy())
 		if controllerutil.AddFinalizer(&nextApp, ExternalCleanupFinalizer) {
-			if err := r.Update(ctx, &nextApp); err != nil {
+			if err := r.Patch(ctx, &nextApp, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -148,8 +164,11 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			if err := r.cleanupExternalState(ctx, &nextApp); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Remove the finalizer via a metadata Patch (see the add path above)
+			// to keep the metadata vs status writes on disjoint subresources.
+			patch := client.MergeFrom(nextApp.DeepCopy())
 			controllerutil.RemoveFinalizer(&nextApp, ExternalCleanupFinalizer)
-			if err := r.Update(ctx, &nextApp); err != nil {
+			if err := r.Patch(ctx, &nextApp, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -157,17 +176,11 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, nil
 	}
 
-	// Mark Reconciling=True at the start of every reconcile loop.
-	apimeta.SetStatusCondition(&nextApp.Status.Conditions, metav1.Condition{
-		Type:               ConditionReconciling,
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: nextApp.Generation,
-		Reason:             "Reconciling",
-		Message:            "Reconciliation in progress",
-	})
-	if err := r.Status().Update(ctx, &nextApp); err != nil {
-		return ctrl.Result{}, err
-	}
+	// NOTE (#98): we intentionally do NOT write an eager Reconciling=True status
+	// here. That mid-pass write re-triggered this controller's own watch and was
+	// the primary driver of the idle hot-loop. The full desired status (including
+	// Reconciling=False on success) is computed in-memory below and written ONCE,
+	// only when it actually differs from the observed status.
 
 	// Validate the full spec using the SAME function the admission webhook calls
 	// (internal/validation.ValidateNextAppSpec) so the two cannot drift. This
@@ -193,7 +206,11 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			Reason:             "InvalidSpec",
 			Message:            "Spec does not meet validation requirements",
 		})
-		_ = r.Status().Update(ctx, &nextApp)
+		// Only write when the status actually changed (#98 no-op guard) so a
+		// persistently-invalid CR does not hot-loop on its own status writes.
+		if !apiequality.Semantic.DeepEqual(observedStatus, &nextApp.Status) {
+			_ = r.Status().Update(ctx, &nextApp)
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -607,8 +624,14 @@ func (r *NextAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		})
 	}
 
-	if err := r.Status().Update(ctx, &nextApp); err != nil {
-		return ctrl.Result{}, err
+	// No-op-status guard (#98): only write status when the freshly-computed
+	// desired status differs from what we observed at the top of the pass. On an
+	// idle, converged object every field is identical, so this skips the write
+	// and the watch event it would otherwise generate — settling the loop.
+	if !apiequality.Semantic.DeepEqual(observedStatus, &nextApp.Status) {
+		if err := r.Status().Update(ctx, &nextApp); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	r.emitEvent(&nextApp, corev1.EventTypeNormal, ReasonReconciled,
@@ -771,7 +794,15 @@ func (r *NextAppReconciler) reconcileNetworkPolicy(ctx context.Context, nextApp 
 
 func (r *NextAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1alpha1.NextApp{}).
+		// GenerationChangedPredicate on the PRIMARY (For) watch only: a
+		// status-only write (metadata.generation is unchanged for status
+		// subresource updates) no longer re-enqueues, which — together with the
+		// no-op-status guard — kills the idle reconcile hot-loop (#98). NOTE: this
+		// also means annotation-only / label-only edits to the NextApp do not
+		// reconcile (generation is bumped only on spec changes). That is the
+		// accepted trade-off. We do NOT filter the Owns(...) watches: drift in an
+		// owned child (ksvc/SA/PVC/NetworkPolicy) must still trigger a reconcile.
+		For(&appsv1alpha1.NextApp{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&servingv1.Service{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.ServiceAccount{}).

--- a/packages/kn-next-operator/internal/controller/reconcile_convergence_test.go
+++ b/packages/kn-next-operator/internal/controller/reconcile_convergence_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/AhmedElBanna80/knext/packages/kn-next-operator/api/v1alpha1"
+	"knative.dev/pkg/apis"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// These tests pin issue #98: the reconciler must CONVERGE — once a NextApp is
+// reconciled and unchanged, a second reconcile pass must perform NO status write
+// (otherwise the status write re-enqueues its own watch event → ~45/s hot-loop).
+// They also assert the finalizer-add no longer races the status update (no
+// "object has been modified" conflict spam), and that the no-op guard does NOT
+// over-suppress real changes (spec change + owned-resource drift still persist).
+
+var _ = Describe("NextApp Controller reconcile convergence (#98)", func() {
+	const (
+		namespace  = "default"
+		validImage = "registry.example.com/app:v1@sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+		// a different valid digest-pinned ref for the spec-change regression test.
+		validImage2 = "registry.example.com/app:v2@sha256:def456abc123def456abc123def456abc123def456abc123def456abc123def4"
+	)
+
+	ctx := context.Background()
+
+	// createAndConverge creates the NextApp, reconciles once (converging), and
+	// registers finalizer-aware cleanup. Returns the namespaced name.
+	createAndConverge := func(name string, spec appsv1alpha1.NextAppSpec) types.NamespacedName {
+		nn := types.NamespacedName{Name: name, Namespace: namespace}
+		spec.Image = orDefault(spec.Image, validImage)
+		nextApp := &appsv1alpha1.NextApp{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       spec,
+		}
+		Expect(k8sClient.Create(ctx, nextApp)).To(Succeed())
+
+		DeferCleanup(func() {
+			cur := &appsv1alpha1.NextApp{}
+			if err := k8sClient.Get(ctx, nn, cur); err == nil {
+				Expect(k8sClient.Delete(ctx, cur)).To(Succeed())
+				cleanup := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+				Eventually(func() bool {
+					_, _ = cleanup.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+					return errors.IsNotFound(k8sClient.Get(ctx, nn, &appsv1alpha1.NextApp{}))
+				}, "10s", "100ms").Should(BeTrue())
+			}
+		})
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		return nn
+	}
+
+	// RED test 1 (primary): an unchanged object must NOT be written on the second
+	// reconcile pass. Fails against current code (the eager Reconciling=True status
+	// write bumps resourceVersion on every pass).
+	It("performs no status write when reconciling an unchanged converged object", func() {
+		nn := createAndConverge("converge-noop", appsv1alpha1.NextAppSpec{Image: validImage})
+
+		before := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, before)).To(Succeed())
+		beforeRV := before.ResourceVersion
+		beforeStatus := *before.Status.DeepCopy()
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		after := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, after)).To(Succeed())
+
+		By("not bumping resourceVersion (no write to the API server)")
+		Expect(after.ResourceVersion).To(Equal(beforeRV),
+			"a no-op reconcile must not write status (resourceVersion must be unchanged)")
+
+		By("leaving the observed status byte-identical")
+		Expect(after.Status).To(Equal(beforeStatus))
+	})
+
+	// Test 2 (no-conflict): two rapid reconciles must not surface a conflict
+	// ("object has been modified"). The finalizer-via-Patch removes the
+	// update/status-update race.
+	It("does not surface IsConflict on two rapid reconciles", func() {
+		nn := types.NamespacedName{Name: "converge-noconflict", Namespace: namespace}
+		nextApp := &appsv1alpha1.NextApp{
+			ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: namespace},
+			Spec:       appsv1alpha1.NextAppSpec{Image: validImage},
+		}
+		Expect(k8sClient.Create(ctx, nextApp)).To(Succeed())
+		DeferCleanup(func() {
+			cur := &appsv1alpha1.NextApp{}
+			if err := k8sClient.Get(ctx, nn, cur); err == nil {
+				Expect(k8sClient.Delete(ctx, cur)).To(Succeed())
+				cleanup := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+				Eventually(func() bool {
+					_, _ = cleanup.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+					return errors.IsNotFound(k8sClient.Get(ctx, nn, &appsv1alpha1.NextApp{}))
+				}, "10s", "100ms").Should(BeTrue())
+			}
+		})
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err1 := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		_, err2 := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+
+		Expect(errors.IsConflict(err1)).To(BeFalse(), "first reconcile must not conflict")
+		Expect(errors.IsConflict(err2)).To(BeFalse(), "second reconcile must not conflict")
+		Expect(err1).NotTo(HaveOccurred())
+		Expect(err2).NotTo(HaveOccurred())
+	})
+
+	// Test 3 (does NOT over-suppress — regression guard): the no-op guard must
+	// only skip TRUE no-ops. A spec change must persist (ObservedGeneration
+	// advances), and owned-resource drift (ksvc Status.URL) must flow into status.
+	It("still writes status when the spec changes (does not over-suppress)", func() {
+		nn := createAndConverge("converge-specchange", appsv1alpha1.NextAppSpec{Image: validImage})
+
+		before := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, before)).To(Succeed())
+		beforeRV := before.ResourceVersion
+
+		// Change the spec to a different valid digest-pinned image.
+		cur := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, cur)).To(Succeed())
+		cur.Spec.Image = validImage2
+		Expect(k8sClient.Update(ctx, cur)).To(Succeed())
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		after := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, after)).To(Succeed())
+
+		By("bumping resourceVersion (the change must persist)")
+		Expect(after.ResourceVersion).NotTo(Equal(beforeRV))
+
+		By("advancing ObservedGeneration on the Ready condition")
+		ready := findCondition(after.Status.Conditions, conditionTypeReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.ObservedGeneration).To(Equal(after.Generation))
+	})
+
+	It("propagates owned ksvc Status.URL into NextApp status (does not over-suppress drift)", func() {
+		nn := createAndConverge("converge-urldrift", appsv1alpha1.NextAppSpec{Image: validImage})
+
+		// Simulate Knative populating the ksvc URL out-of-band.
+		ksvc := &servingv1.Service{}
+		Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+		ksvc.Status.URL = apis.HTTP("converge-urldrift.default.example.com")
+		Expect(k8sClient.Status().Update(ctx, ksvc)).To(Succeed())
+
+		reconciler := &NextAppReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		after := &appsv1alpha1.NextApp{}
+		Expect(k8sClient.Get(ctx, nn, after)).To(Succeed())
+		Expect(after.Status.URL).To(Equal("http://converge-urldrift.default.example.com"))
+	})
+})


### PR DESCRIPTION
Closes #98.

Fixes the operator reconcile **hot-loop (~45/s on an idle NextApp)** and the status-write **conflict spam** (amplified by #92's traffic-status write). Root cause: the `For(&NextApp{})` watch had no predicate and the reconciler wrote status every pass (an unconditional `Reconciling=True` mid-pass write), so each status write re-enqueued the object; separately, the finalizer `r.Update` raced `r.Status().Update`.

**Three fixes** (all in `internal/controller/nextapp_controller.go`):
1. **`GenerationChangedPredicate` on the `For` watch only** — status-subresource writes don't bump `generation`, so they no longer re-enqueue; spec edits still do. The 4 `Owns(...)` watches stay unfiltered so owned-resource drift still reconciles.
2. **No-op-status guard** — removed the eager `Reconciling=True` write; snapshot observed status, compute the *full* desired status (URL, CurrentTraffic, all conditions) in-memory, and skip `Status().Update` when `apiequality.Semantic.DeepEqual` says nothing changed.
3. **Finalizer via `client.MergeFrom` Patch** (add + remove) instead of `r.Update` — finalizers (metadata) and status (subresource) are now disjoint writes that don't race.

**Tests** (`reconcile_convergence_test.go`, envtest, RED→GREEN): a second reconcile of an unchanged converged object performs **no** write (resourceVersion + status byte-identical) — the RED test against the old code; no `IsConflict` on rapid reconciles; and the over-suppression guards (a real spec change bumps resourceVersion + advances `ObservedGeneration`; an owned ksvc `Status.URL` drift still propagates) so the guard only skips true no-ops.

**Trade-off (documented):** `GenerationChangedPredicate` means annotation/label-only edits to a NextApp won't reconcile (acceptable — the reconciler is spec-driven).

**Honest scope:** the unit tests prove the *cause* is gone (no status write + no conflict on an unchanged object). The actual ~0/s-on-idle rate is a manager/informer-level behavior that envtest's direct-`Reconcile` calls bypass — that measurement is a live-kind check (validated by the integration tester).

**Verified:** `make test` GREEN (controller coverage 60.8%→61.6%) · `go build`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
