### PR TITLE
CI: run operator Go tests (envtest + install bundle) on every PR (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,46 @@ jobs:
             echo "Run 'make generate && make manifests' locally and commit the result."
             exit 1
           fi
+
+  operator-test:
+    # Issue #102: actually RUN the operator Go test suite in CI. `make test`
+    # self-provisions envtest (setup-envtest dep) and excludes /e2e. We build the
+    # install bundle first (make build-installer renders dist/install.yaml) so the
+    # internal/install namespace-immunity tests RUN instead of skipping, and set
+    # KNEXT_REQUIRE_BUNDLE=1 so a missing bundle HARD-FAILS — a green check can never
+    # mean "skipped".
+    name: Operator Go tests (envtest + install bundle)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/kn-next-operator/go.mod
+          cache: true
+          cache-dependency-path: packages/kn-next-operator/go.sum
+      - name: Resolve envtest k8s version
+        working-directory: packages/kn-next-operator
+        run: echo "ENVTEST_K8S_VERSION=$(make print-envtest-version)" >> "$GITHUB_ENV"
+      - name: Cache envtest + tool binaries
+        uses: actions/cache@v4
+        with:
+          path: packages/kn-next-operator/bin
+          key: ${{ runner.os }}-envtest-${{ env.ENVTEST_K8S_VERSION }}-${{ hashFiles('packages/kn-next-operator/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-envtest-
+      - name: Set up envtest binaries
+        working-directory: packages/kn-next-operator
+        run: make setup-envtest
+      - name: Build install bundle (so immunity tests run, not skip)
+        working-directory: packages/kn-next-operator
+        run: make build-installer
+      - name: Run operator Go test suite (envtest)
+        working-directory: packages/kn-next-operator
+        env:
+          # Converts the dist/install.yaml skip guards into a HARD failure if the
+          # bundle is missing — the namespace-immunity contract must be gated.
+          KNEXT_REQUIRE_BUNDLE: '1'
+        run: make test

--- a/packages/kn-next-operator/Makefile
+++ b/packages/kn-next-operator/Makefile
@@ -229,6 +229,10 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
+.PHONY: print-envtest-version
+print-envtest-version: ## Print the resolved ENVTEST_K8S_VERSION (used by CI for the envtest cache key).
+	@echo "$(ENVTEST_K8S_VERSION)"
+
 .PHONY: setup-envtest
 setup-envtest: envtest ## Download the binaries required for ENVTEST in the local bin directory.
 	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."

--- a/packages/kn-next-operator/internal/install/bundle_test.go
+++ b/packages/kn-next-operator/internal/install/bundle_test.go
@@ -12,6 +12,23 @@ import (
 	"testing"
 )
 
+// requireBundle returns the path to the rendered dist/install.yaml. When the bundle
+// is absent it normally t.Skip()s (a clean checkout has not run `make build-installer`,
+// since dist/install.yaml is gitignored). But in CI we set KNEXT_REQUIRE_BUNDLE=1 so a
+// missing bundle is a HARD failure instead — the namespace-immunity contract must be
+// gated, and a green check can never silently mean "skipped" (issue #102).
+func requireBundle(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join("..", "..", "dist", "install.yaml")
+	if _, err := os.Stat(p); err != nil {
+		if os.Getenv("KNEXT_REQUIRE_BUNDLE") == "1" {
+			t.Fatalf("dist/install.yaml not generated but KNEXT_REQUIRE_BUNDLE=1: run `make build-installer` first (%v)", err)
+		}
+		t.Skip("dist/install.yaml not generated (run `make build-installer`); live-apply covered by test/e2e")
+	}
+	return p
+}
+
 // repoFile reads a file relative to the operator package root (two dirs up from
 // internal/install).
 func repoFile(t *testing.T, rel string) string {

--- a/packages/kn-next-operator/internal/install/ci_workflow_test.go
+++ b/packages/kn-next-operator/internal/install/ci_workflow_test.go
@@ -1,0 +1,70 @@
+// Package install also verifies the operator CI gating (issue #102): the operator
+// Go test suite (controller envtest + internal/install assertions) must actually run
+// in CI. The gap was that .github/workflows/ci.yml ran vitest + codegen-diff +
+// no-:latest guard but NO job ran `make test`, so a reconciler/validation regression
+// could merge green and the install-bundle namespace-immunity guarantees were never
+// gated (they SKIP when dist/install.yaml is absent — it is gitignored).
+package install
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func readCIWorkflow(t *testing.T) string {
+	t.Helper()
+	return repoFile(t, "../../.github/workflows/ci.yml")
+}
+
+// TestCIWorkflowIsValidYAML guards against a malformed ci.yml.
+func TestCIWorkflowIsValidYAML(t *testing.T) {
+	var v any
+	if err := yaml.Unmarshal([]byte(readCIWorkflow(t)), &v); err != nil {
+		t.Fatalf("ci.yml is not valid YAML: %v", err)
+	}
+}
+
+// TestCIRunsOperatorTestJob asserts ci.yml defines a jobs.operator-test job that
+// builds the install bundle and runs the operator Go test suite (envtest), so a red
+// operator unit/envtest fails the PR and the bundle-immunity assertions actually run.
+func TestCIRunsOperatorTestJob(t *testing.T) {
+	wf := readCIWorkflow(t)
+
+	var doc struct {
+		Jobs map[string]any `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal([]byte(wf), &doc); err != nil {
+		t.Fatalf("decoding ci.yml: %v", err)
+	}
+
+	job, ok := doc.Jobs["operator-test"]
+	if !ok {
+		t.Fatalf("ci.yml jobs.operator-test missing: the operator Go test suite is not run in CI")
+	}
+
+	// Re-marshal just the job so we can string-assert its steps (mirrors the
+	// string-assert style of workflow_test.go).
+	jobYAML, err := yaml.Marshal(job)
+	if err != nil {
+		t.Fatalf("re-marshaling operator-test job: %v", err)
+	}
+	js := string(jobYAML)
+
+	for _, want := range []string{
+		"make setup-envtest",
+		"make build-installer",
+		"make test",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("jobs.operator-test must run %q (not found in job steps)", want)
+		}
+	}
+
+	// The bundle-immunity tests must hard-fail (not skip) in CI when the bundle is
+	// missing, so a green check can never mean "skipped".
+	if !strings.Contains(js, "KNEXT_REQUIRE_BUNDLE") {
+		t.Errorf("jobs.operator-test must set KNEXT_REQUIRE_BUNDLE so a missing bundle hard-fails")
+	}
+}

--- a/packages/kn-next-operator/internal/install/ci_workflow_test.go
+++ b/packages/kn-next-operator/internal/install/ci_workflow_test.go
@@ -63,8 +63,10 @@ func TestCIRunsOperatorTestJob(t *testing.T) {
 	}
 
 	// The bundle-immunity tests must hard-fail (not skip) in CI when the bundle is
-	// missing, so a green check can never mean "skipped".
-	if !strings.Contains(js, "KNEXT_REQUIRE_BUNDLE") {
-		t.Errorf("jobs.operator-test must set KNEXT_REQUIRE_BUNDLE so a missing bundle hard-fails")
+	// missing, so a green check can never mean "skipped". requireBundle only fatals
+	// when KNEXT_REQUIRE_BUNDLE == "1", so assert the value — not just the key — or a
+	// stray KNEXT_REQUIRE_BUNDLE: '0' would silently disarm the gate yet pass here.
+	if !strings.Contains(js, `KNEXT_REQUIRE_BUNDLE: "1"`) {
+		t.Errorf(`jobs.operator-test must set KNEXT_REQUIRE_BUNDLE: '1' so a missing bundle hard-fails`)
 	}
 }

--- a/packages/kn-next-operator/internal/install/ingress_class_test.go
+++ b/packages/kn-next-operator/internal/install/ingress_class_test.go
@@ -6,11 +6,8 @@
 package install
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
-
-	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -59,9 +56,7 @@ func TestConfigNetworkManifestSetsKourierIngressClass(t *testing.T) {
 // top-level namespace transformer) with the kourier ingress-class. Skip cleanly when
 // the bundle has not been generated (run `make build-installer`).
 func TestInstallBundleCarriesKourierIngressClass(t *testing.T) {
-	if _, err := os.Stat(filepath.Join("..", "..", "dist", "install.yaml")); err != nil {
-		t.Skip("dist/install.yaml not generated (run `make build-installer`)")
-	}
+	requireBundle(t)
 	raw := repoFile(t, "dist/install.yaml")
 	dec := yaml.NewDecoder(strings.NewReader(raw))
 

--- a/packages/kn-next-operator/internal/install/pvc_feature_flags_test.go
+++ b/packages/kn-next-operator/internal/install/pvc_feature_flags_test.go
@@ -8,11 +8,8 @@
 package install
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
-
-	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -65,9 +62,7 @@ func TestConfigFeaturesManifestEnablesPVCFlags(t *testing.T) {
 // transformer) with both PVC feature flags enabled. Skip cleanly when the bundle has
 // not been generated (run `make build-installer`).
 func TestInstallBundleEnablesPVCFlags(t *testing.T) {
-	if _, err := os.Stat(filepath.Join("..", "..", "dist", "install.yaml")); err != nil {
-		t.Skip("dist/install.yaml not generated (run `make build-installer`)")
-	}
+	requireBundle(t)
 	raw := repoFile(t, "dist/install.yaml")
 	dec := yaml.NewDecoder(strings.NewReader(raw))
 

--- a/packages/kn-next-operator/internal/install/workflow_test.go
+++ b/packages/kn-next-operator/internal/install/workflow_test.go
@@ -7,8 +7,6 @@
 package install
 
 import (
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -120,10 +118,9 @@ func TestReadmeUrlMatchesReleaseTag(t *testing.T) {
 // existing kind e2e harness (test/e2e), which is too heavy to stand up on every PR.
 func TestInstallBundleIsStructurallyValid(t *testing.T) {
 	// dist/install.yaml is a gitignored build artifact (run `make build-installer`).
-	// Skip cleanly on a clean checkout rather than hard-failing.
-	if _, err := os.Stat(filepath.Join("..", "..", "dist", "install.yaml")); err != nil {
-		t.Skip("dist/install.yaml not generated (run `make build-installer`); live-apply covered by test/e2e")
-	}
+	// Skip cleanly on a clean checkout rather than hard-failing — but hard-fail under
+	// KNEXT_REQUIRE_BUNDLE=1 (CI) so a green check can never mean "skipped".
+	requireBundle(t)
 	raw := repoFile(t, "dist/install.yaml")
 	dec := yaml.NewDecoder(strings.NewReader(raw))
 


### PR DESCRIPTION
Closes #102.

Closes the CI coverage hole where **no job ran the operator Go test suite** (controller envtest, validation, `internal/install`) — operator regressions could merge green — and where the `internal/install` bundle-immunity tests **silently skipped** when the gitignored `dist/install.yaml` was absent.

**New `operator-test` job** (`.github/workflows/ci.yml`, gates PRs): `setup-go` (pinned via `go-version-file`) + an `actions/cache` of `packages/kn-next-operator/bin` keyed on the **dynamically-resolved** `ENVTEST_K8S_VERSION` (+ `go.sum`) → `make setup-envtest` → `make build-installer` (so the rendered-bundle immunity tests **run**, not skip) → `make test`. `make test` already self-provisions envtest and excludes `/e2e`, so no Makefile test-target change — only a tiny `print-envtest-version` helper for the cache key.

**No-skip hardening:** a shared `requireBundle(t)` helper turns the three bundle-immunity skip guards (`TestInstallBundleCarriesKourierIngressClass`, `TestInstallBundleEnablesPVCFlags`, `TestInstallBundleIsStructurallyValid`) into **hard failures** under `KNEXT_REQUIRE_BUNDLE=1` (set by the CI job). Locally (env unset) they keep the friendly skip — so a green CI check can never mean "the immunity contract was skipped".

**Tests (TDD):** `ci_workflow_test.go` (a contract test that parses `ci.yml` and asserts the `operator-test` job exists with the three make steps **and** `KNEXT_REQUIRE_BUNDLE: "1"` — the guard pass tightened it to assert the value, not just the key, so a stray `'0'` can't disarm the gate).

**Verified locally:** `KNEXT_REQUIRE_BUNDLE=1 make test` GREEN with the 3 bundle tests **running** (0 SKIP); `rm dist/install.yaml && KNEXT_REQUIRE_BUNDLE=1 go test ./internal/install/...` **fails** (gate bites); env-unset → friendly skip; `ci.yml` parses. (Cache hit/miss + actual PR-gating are only fully observable once this runs on GitHub — stated honestly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
