### PR TITLE
e2e: scale-to-zero activation regression (#39)

### DIFF
--- a/.github/workflows/operator-e2e-nightly.yml
+++ b/.github/workflows/operator-e2e-nightly.yml
@@ -88,12 +88,40 @@ jobs:
           kubectl wait --for=condition=Available --timeout=300s \
             -n knative-serving deployment/controller deployment/webhook deployment/autoscaler
 
+      # SCALE_TEST_IMAGE MUST be a real, pullable, digest-pinned file-manager image
+      # that serves /api/health (the #39 activation spec asserts an HTTP 200 from a
+      # woken pod; #38 scrapes /api/metrics). The in-code default in
+      # test/e2e/scale_*_test.go is an all-zeros placeholder digest that is
+      # DELIBERATELY UNPULLABLE — if it ever reaches the cluster the ksvc never
+      # becomes Ready (ErrImagePull) and the specs fail at "ksvc not Ready". So this
+      # step FAILS FAST with a clear message when no image is provided, rather than
+      # burning 5 minutes on a BeforeSuite timeout.
+      #   - workflow_dispatch: pass the digest via the `scale_test_image` input.
+      #   - schedule (nightly): set the repo/org variable `vars.SCALE_TEST_IMAGE`
+      #     to a freshly built+pushed file-manager digest (a publish job should
+      #     update it), or this run is skipped with a clear log line.
+      - name: Resolve SCALE_TEST_IMAGE
+        id: scale_image
+        run: |
+          set -euo pipefail
+          img="${{ inputs.scale_test_image || vars.SCALE_TEST_IMAGE }}"
+          if [ -z "$img" ]; then
+            echo "::warning::No SCALE_TEST_IMAGE provided (dispatch input empty and vars.SCALE_TEST_IMAGE unset)."
+            echo "The scale e2e specs need a real, pullable, digest-pinned file-manager image that serves /api/health."
+            echo "Skipping the scale e2e run for this trigger."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using SCALE_TEST_IMAGE=$img"
+            echo "image=$img" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run scale-to-zero e2e suite (cache #38 + activation #39)
+        if: steps.scale_image.outputs.skip != 'true'
         working-directory: packages/kn-next-operator
         env:
           KIND_CLUSTER: kn-next-operator-test-e2e
           CERT_MANAGER_INSTALL_SKIP: 'true'
-          SCALE_TEST_IMAGE: ${{ inputs.scale_test_image }}
+          SCALE_TEST_IMAGE: ${{ steps.scale_image.outputs.image }}
         run: make test-e2e-scale
 
       - name: Tear down kind cluster

--- a/.github/workflows/operator-e2e-nightly.yml
+++ b/.github/workflows/operator-e2e-nightly.yml
@@ -1,13 +1,21 @@
 name: Operator E2E (nightly / dispatch)
 
-# A2-2 (#38) Layer 2: the REAL scale-to-zero bytecode-cache invariant on a live
-# kind + Knative cluster (test/e2e/scale_to_zero_cache_test.go, build tag
-# `e2e_scale`).
+# Layer 2 of the scale-to-zero suite (build tag `e2e_scale`) — the REAL invariants
+# on a live kind + Knative cluster. `make test-e2e-scale` runs ALL e2e_scale
+# specs, so this one job now covers BOTH:
+#   - A2-2 (#38): bytecode cache SURVIVES a scale-to-zero cycle
+#     (test/e2e/scale_to_zero_cache_test.go)
+#   - A2-3 (#39): a minScale:0 app idles to 0 replicas then a request through the
+#     Knative activator wakes a pod and returns 200
+#     (test/e2e/scale_from_zero_test.go)
+# The operator is deployed once for the whole suite (test/e2e/scale_suite_test.go).
 #
 # Deliberately NOT in ci.yml: it needs a persistent kind cluster with Knative
-# Serving (scale-to-zero) + an RWO PVC bound across a scale cycle, and the timing
-# sits within PR-CI noise. The per-PR gate that proves the mechanism is the
-# deterministic vitest test apps/file-manager/bytecode-cache-reuse.test.ts.
+# Serving (scale-to-zero) + (for #38) an RWO PVC bound across a scale cycle, and
+# the timing sits within PR-CI noise. The per-PR gates that prove the mechanisms
+# are deterministic: the vitest test apps/file-manager/bytecode-cache-reuse.test.ts
+# (#38) and the envtest min-scale:0/max-scale:1 assertion in
+# internal/controller/reconcile_output_test.go (#39).
 #
 # Triggers: nightly schedule + manual workflow_dispatch only.
 #
@@ -33,7 +41,7 @@ permissions:
 
 jobs:
   scale-to-zero-cache:
-    name: scale-to-zero bytecode cache (e2e_scale)
+    name: scale-to-zero suite — cache (#38) + activation (#39) (e2e_scale)
     runs-on: ubuntu-latest
     # The real invariant can be flaky on shared runners (Knative install + scale
     # timing); never let a nightly hiccup page anyone. Failures are reviewed, not
@@ -58,8 +66,10 @@ jobs:
         run: kind create cluster --name kn-next-operator-test-e2e --wait 120s
 
       - name: Install Knative Serving (scale-to-zero)
-        # TODO(#39): factor this Knative bootstrap into a shared composite action
-        # once the scale-to-zero regression workflow needs the same steps.
+        # The config-autoscaler patch below (scale-to-zero-pod-retention-period:0s,
+        # short stable-window) is what makes BOTH the #38 cache spec and the #39
+        # activation spec observe a true cold start in this single job — scale
+        # timing is cluster config, not the NextApp CR.
         run: |
           set -euo pipefail
           KNATIVE_VERSION="knative-v1.16.0"
@@ -78,7 +88,7 @@ jobs:
           kubectl wait --for=condition=Available --timeout=300s \
             -n knative-serving deployment/controller deployment/webhook deployment/autoscaler
 
-      - name: Run scale-to-zero bytecode-cache e2e
+      - name: Run scale-to-zero e2e suite (cache #38 + activation #39)
         working-directory: packages/kn-next-operator
         env:
           KIND_CLUSTER: kn-next-operator-test-e2e

--- a/packages/kn-next-operator/Makefile
+++ b/packages/kn-next-operator/Makefile
@@ -100,7 +100,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: test-e2e-scale
-test-e2e-scale: manifests generate fmt vet ## Run the scale-to-zero bytecode-cache e2e (#38). Requires a kind+Knative cluster; NOT run in PR CI. Nightly/dispatch only.
+test-e2e-scale: manifests generate fmt vet ## Run the scale-to-zero e2e suite: bytecode-cache survival (#38) + scale-from-zero activation (#39). Requires a kind+Knative cluster; NOT run in PR CI. Nightly/dispatch only.
 	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e_scale ./test/e2e/ -v -ginkgo.v -run TestE2E
 
 .PHONY: lint

--- a/packages/kn-next-operator/config/manager/manager.yaml
+++ b/packages/kn-next-operator/config/manager/manager.yaml
@@ -63,20 +63,21 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        # BOOTSTRAP PLACEHOLDER DIGEST (issue #76):
-        # The operator image is built/scanned/signed/pushed to
-        #   ghcr.io/getknext-dev/kn-next-operator
-        # by .github/workflows/operator-supply-chain.yml, but only the FIRST push to
-        # `main` produces a real digest — it cannot exist before that push. Until then
-        # this stays a clearly-fake all-zeros sha256 so the check-no-latest.sh guard
-        # (which only requires a digest, never :latest) still passes.
-        # The release job substitutes the real pushed digest into dist/install.yaml
-        # (see the "Build installer + pin real digest" step in
-        # .github/workflows/operator-supply-chain.yml, which sed-pins the digest into
-        # config/manager/kustomization.yaml then runs `make build-installer`).
-        # To set it manually after a push:
-        #   docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/getknext-dev/kn-next-operator:<tag>
-        image: ghcr.io/getknext-dev/kn-next-operator:v0.1.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        # LOGICAL IMAGE NAME (issue #39): this is the bare kustomize logical name
+        # `controller`, NOT a real image ref. config/manager/kustomization.yaml's
+        # `images:` entry (name: controller) rewrites it to the digest-pinned
+        # ghcr.io/getknext-dev/kn-next-operator:v0.1.0@sha256:... in every rendered
+        # bundle, so `make build-installer` stays digest-pinned and check-no-latest.sh
+        # passes. `make deploy IMG=X` runs `kustomize edit set image controller=X`,
+        # which now matches THIS name and actually overrides the deployed image.
+        #
+        # PREVIOUSLY this was the literal `ghcr.io/...@sha256:0000...` placeholder,
+        # whose container image NAME (ghcr.io/getknext-dev/kn-next-operator) did NOT
+        # match the kustomization override name (`controller`) — so `set image
+        # controller=X` was a silent no-op and every deploy used the unpullable
+        # all-zeros digest (ErrImagePull). See kustomization.yaml for the real digest
+        # the bundle resolves to and the bootstrap/release notes for issue #76.
+        image: controller
         name: manager
         ports: []
         securityContext:

--- a/packages/kn-next-operator/internal/controller/reconcile_output_test.go
+++ b/packages/kn-next-operator/internal/controller/reconcile_output_test.go
@@ -150,6 +150,31 @@ var _ = Describe("NextApp Controller reconcile output", func() {
 			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/min-scale", "0"))
 			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/max-scale", "10"))
 		})
+
+		It("renders scale-to-zero-eligible annotations (min-scale 0, max-scale 1) for #39 activation", func() {
+			// A2-3 (#39): the activation path requires the revision to be eligible
+			// to scale to zero (min-scale 0) and to wake on demand. A single-replica
+			// ceiling (max-scale 1) makes the nightly scale-from-zero e2e
+			// deterministic — exactly one pod is woken by the activator. This is the
+			// deterministic per-PR gate that proves the operator maps the CR onto the
+			// autoscaling annotations the activator relies on.
+			nn := reconcileOnce("ksvc-scale-from-zero", appsv1alpha1.NextAppSpec{
+				Image: validImage,
+				Scaling: &appsv1alpha1.ScalingSpec{
+					MinScale: 0,
+					MaxScale: 1,
+				},
+			})
+
+			ksvc := &servingv1.Service{}
+			Expect(k8sClient.Get(ctx, nn, ksvc)).To(Succeed())
+
+			annotations := ksvc.Spec.Template.Annotations
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/min-scale", "0"),
+				"min-scale must be 0 so the revision is eligible to scale to zero")
+			Expect(annotations).To(HaveKeyWithValue("autoscaling.knative.dev/max-scale", "1"),
+				"max-scale must be 1 so exactly one pod is woken on activation")
+		})
 	})
 
 	Context("ServiceAccount", func() {

--- a/packages/kn-next-operator/internal/install/bundle_test.go
+++ b/packages/kn-next-operator/internal/install/bundle_test.go
@@ -29,35 +29,68 @@ const (
 	staleOwner = "ahmedelbanna80"
 )
 
-// AC: manager.yaml + kustomization.yaml reference the getknext-dev owner.
+// AC: the effective deploy-time image (the kustomization override) references the
+// getknext-dev owner, and no manifest carries the stale owner.
+//
+// NOTE(#39): manager.yaml's container `image:` is now the bare logical kustomize
+// name `controller` (NOT a real ref) — the digest-pinned getknext-dev ref lives in
+// kustomization.yaml, which rewrites `controller` in every rendered bundle. That is
+// what makes `make deploy IMG=X` (kustomize edit set image controller=X) actually
+// override the image; see TestManagerUsesLogicalControllerName below.
 func TestManagerManifestsUseGetknextOwner(t *testing.T) {
+	c := repoFile(t, "config/manager/kustomization.yaml")
+	if !strings.Contains(c, wantOwner) {
+		t.Errorf("kustomization.yaml: expected image owner %q, not found", wantOwner)
+	}
 	for _, rel := range []string{
 		"config/manager/manager.yaml",
 		"config/manager/kustomization.yaml",
 	} {
-		c := repoFile(t, rel)
-		if !strings.Contains(c, wantOwner) {
-			t.Errorf("%s: expected image owner %q, not found", rel, wantOwner)
-		}
-		if strings.Contains(c, staleOwner) {
+		if strings.Contains(repoFile(t, rel), staleOwner) {
 			t.Errorf("%s: stale owner %q must be removed", rel, staleOwner)
 		}
 	}
 }
 
-// AC: the manager image is digest-pinned (@sha256:) and never :latest.
+// AC(#39): manager.yaml's container image is the bare logical kustomize name
+// `controller`, and kustomization.yaml declares an `images:` override under that
+// SAME name. This is the contract that was broken (manager.yaml hardcoded the
+// ghcr ref, whose image name did not match the `controller` override → `kustomize
+// edit set image controller=X` was a silent no-op → every deploy used the
+// unpullable placeholder). The two names MUST stay in lock-step.
+func TestManagerUsesLogicalControllerName(t *testing.T) {
+	mgr := repoFile(t, "config/manager/manager.yaml")
+	imgLine := regexp.MustCompile(`(?m)^\s*image:\s*(\S+)\s*$`)
+	m := imgLine.FindStringSubmatch(mgr)
+	if m == nil {
+		t.Fatalf("manager.yaml: no container image: line found")
+	}
+	if m[1] != "controller" {
+		t.Errorf("manager.yaml container image must be the bare logical name %q so the "+
+			"kustomization override applies, got %q", "controller", m[1])
+	}
+
+	kz := repoFile(t, "config/manager/kustomization.yaml")
+	if !regexp.MustCompile(`(?m)^\s*-?\s*name:\s*controller\s*$`).MatchString(kz) {
+		t.Errorf("kustomization.yaml must declare an images override under name %q "+
+			"(matching the manager container image name)", "controller")
+	}
+}
+
+// AC: the effective deploy-time image (kustomization override) is digest-pinned
+// (@sha256:) and never :latest.
 func TestManagerImageDigestPinned(t *testing.T) {
-	imgLine := regexp.MustCompile(`(?m)^\s*image:\s*ghcr\.io/getknext-dev/kn-next-operator:[^\s]+`)
-	c := repoFile(t, "config/manager/manager.yaml")
-	m := imgLine.FindString(c)
-	if m == "" {
-		t.Fatalf("manager.yaml: no getknext-dev image line found")
+	c := repoFile(t, "config/manager/kustomization.yaml")
+	if strings.Contains(c, ":latest") {
+		t.Errorf("kustomization.yaml image override must not be :latest")
 	}
-	if strings.Contains(m, ":latest") {
-		t.Errorf("manager.yaml image must not be :latest: %q", m)
+	newTag := regexp.MustCompile(`(?m)^\s*newTag:\s*(\S+)`)
+	m := newTag.FindStringSubmatch(c)
+	if m == nil {
+		t.Fatalf("kustomization.yaml: no newTag line found")
 	}
-	if !strings.Contains(m, "@sha256:") {
-		t.Errorf("manager.yaml image must be digest-pinned (@sha256:): %q", m)
+	if !strings.Contains(m[1], "@sha256:") {
+		t.Errorf("kustomization newTag must be digest-pinned (@sha256:): %q", m[1])
 	}
 }
 

--- a/packages/kn-next-operator/test/e2e/e2e_suite_test.go
+++ b/packages/kn-next-operator/test/e2e/e2e_suite_test.go
@@ -38,6 +38,11 @@ var (
 	shouldCleanupCertManager = false
 )
 
+// operatorNamespace is where `make deploy` installs the controller-manager.
+// Shared by the e2e_scale specs (#38, #39) so the operator is deployed exactly
+// once for the whole suite (see deployOperatorOnce / undeployOperator below).
+const operatorNamespace = "kn-next-operator-system"
+
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //

--- a/packages/kn-next-operator/test/e2e/e2e_suite_test.go
+++ b/packages/kn-next-operator/test/e2e/e2e_suite_test.go
@@ -66,9 +66,18 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
 	setupCertManager()
+
+	// Tag-specific extension of the single suite setup. No-op under the plain
+	// `e2e` tag; under `e2e_scale` it deploys the operator ONCE for the whole
+	// suite so the #38 and #39 specs share one controller-manager. Ginkgo allows
+	// only one BeforeSuite, which is why this is a hook, not a second BeforeSuite.
+	extraSuiteSetup()
 })
 
 var _ = AfterSuite(func() {
+	// Mirror of extraSuiteSetup; runs before CertManager teardown so the operator
+	// is removed first. No-op under the plain `e2e` tag.
+	extraSuiteTeardown()
 	teardownCertManager()
 })
 

--- a/packages/kn-next-operator/test/e2e/scale_from_zero_test.go
+++ b/packages/kn-next-operator/test/e2e/scale_from_zero_test.go
@@ -1,0 +1,154 @@
+//go:build e2e_scale
+// +build e2e_scale
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e — Layer 2 of A2-3 (#39): the REAL scale-to-zero ACTIVATION
+// invariant on a live kind + Knative cluster.
+//
+// WHAT THIS PROVES (distinct from #38):
+//
+//	#38 proves the bytecode cache SURVIVES a scale-to-zero cycle. #39 proves the
+//	autoscaler ACTIVATION path: a NextApp with minScale:0 idles down to 0
+//	replicas, and a single request through the Knative activator wakes a pod and
+//	returns 200. That is the scale-to-zero regression A2-3 asks for: "assert
+//	replicas reach 0 then serve a request post-activation".
+//
+// WHY A SEPARATE BUILD TAG (`e2e_scale`, not `e2e`):
+//
+//	This needs a persistent kind cluster with Knative Serving (scale-to-zero)
+//	whose config-autoscaler is patched to retain pods for 0s — none of which
+//	exists in standard per-PR CI, where scale timing also sits within noise. So
+//	this runs only on the nightly / workflow_dispatch operator-e2e workflow. The
+//	per-PR gate that proves the *mechanism* is the deterministic envtest in
+//	internal/controller/reconcile_output_test.go, which asserts the operator
+//	renders min-scale:0 / max-scale:1 (scale-to-zero eligibility) onto the ksvc.
+//
+// DELIBERATELY DECOUPLED FROM #59:
+//
+//	This spec deploys a MINIMAL NextApp — no bytecode cache, no PVC, no
+//	observability sidecar. The activation path does not depend on the PVC wiring
+//	(#59); it only needs a ksvc that can scale to zero and serve /api/health. It
+//	uses its OWN namespace + app name so it never collides with #38's spec, and
+//	the operator deploy is shared once via scale_suite_test.go's BeforeSuite.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/test/utils"
+)
+
+const (
+	// scaleFromZeroNamespace is the dedicated namespace for the #39 spec — kept
+	// distinct from #38's so the two Ordered Describes never collide.
+	scaleFromZeroNamespace = "kn-next-scalefromzero-test"
+	// scaleFromZeroAppName is the NextApp / Knative Service name under test.
+	scaleFromZeroAppName = "scale-from-zero-app"
+	// scaleFromZeroImageDefault is the file-manager image (digest-pinned; the
+	// operator rejects :latest). Overridable via SCALE_TEST_IMAGE in the nightly
+	// workflow so it can point at a freshly built+pushed digest.
+	scaleFromZeroImageDefault = "dev.local/file-manager@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+var _ = Describe("ScaleFromZero activation (A2-3 / #39)", Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	BeforeAll(func() {
+		// The operator is deployed ONCE for the whole e2e_scale suite by the
+		// shared BeforeSuite (scale_suite_test.go); this spec only manages its
+		// OWN namespace + minimal NextApp CR.
+		By("creating the scale-from-zero namespace")
+		_, _ = utils.Kubectl("create", "ns", scaleFromZeroNamespace)
+
+		By("applying a MINIMAL NextApp CR (minScale:0/maxScale:1, no cache/PVC)")
+		Expect(applyManifest(scaleFromZeroManifest())).To(Succeed(), "failed to apply NextApp CR")
+	})
+
+	AfterAll(func() {
+		By("deleting the scale-from-zero namespace")
+		_, _ = utils.Kubectl("delete", "ns", scaleFromZeroNamespace, "--ignore-not-found")
+	})
+
+	It("idles to zero replicas then serves a 200 on activation", func() {
+		By("waiting for the Knative service to become Ready")
+		Eventually(func(g Gomega) {
+			out, err := utils.Kubectl("get", "ksvc", scaleFromZeroAppName, "-n", scaleFromZeroNamespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("True"), "ksvc not Ready")
+		}).Should(Succeed())
+
+		By("waiting for the service to scale to zero (idle -> 0 replicas)")
+		Expect(utils.WaitForScaleToZero(scaleFromZeroNamespace, scaleFromZeroAppName)).To(Succeed())
+
+		By("confirming there are 0 Running pods before activation")
+		n, err := utils.KnativeReadyPodCount(scaleFromZeroNamespace, scaleFromZeroAppName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(0), "service was not at zero replicas before activation")
+
+		By("activating via a request to /api/health through the Knative activator")
+		var status int
+		var body string
+		Eventually(func(g Gomega) {
+			status, body, err = utils.ActivateAndGet(scaleFromZeroNamespace, scaleFromZeroAppName, "/api/health")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal(200), "activation request did not return 200")
+		}).Should(Succeed())
+		_, _ = fmt.Fprintf(GinkgoWriter, "activation response (%d): %s\n", status, body)
+
+		By("asserting the activator woke at least one pod (scaled up from zero)")
+		Expect(utils.WaitForScaleFromZero(scaleFromZeroNamespace, scaleFromZeroAppName)).To(Succeed())
+		n, err = utils.KnativeReadyPodCount(scaleFromZeroNamespace, scaleFromZeroAppName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(BeNumerically(">=", 1), "no pod was woken on activation")
+
+		By("asserting the /api/health body carries the deep-health status marker")
+		// apps/file-manager/src/app/api/health/route.ts returns
+		// JSON.stringify(checkDeepHealth()), whose payload includes a "status"
+		// field ("ok"/"degraded" -> 200). The presence of that marker proves the
+		// woken pod served the real app route, not an activator/ingress error page.
+		Expect(body).To(ContainSubstring(`"status"`),
+			"activation response body is not the /api/health payload")
+	})
+})
+
+// scaleFromZeroManifest renders a MINIMAL NextApp CR for the #39 activation test:
+// minScale:0/maxScale:1, no cache/PVC/observability — decoupled from #59.
+func scaleFromZeroManifest() string {
+	image := scaleFromZeroImageDefault
+	if v := os.Getenv("SCALE_TEST_IMAGE"); v != "" {
+		image = v
+	}
+	return fmt.Sprintf(`apiVersion: apps.kn-next.dev/v1alpha1
+kind: NextApp
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image: %q
+  scaling:
+    minScale: 0
+    maxScale: 1
+`, scaleFromZeroAppName, scaleFromZeroNamespace, image)
+}

--- a/packages/kn-next-operator/test/e2e/scale_from_zero_test.go
+++ b/packages/kn-next-operator/test/e2e/scale_from_zero_test.go
@@ -64,9 +64,15 @@ const (
 	scaleFromZeroNamespace = "kn-next-scalefromzero-test"
 	// scaleFromZeroAppName is the NextApp / Knative Service name under test.
 	scaleFromZeroAppName = "scale-from-zero-app"
-	// scaleFromZeroImageDefault is the file-manager image (digest-pinned; the
-	// operator rejects :latest). Overridable via SCALE_TEST_IMAGE in the nightly
-	// workflow so it can point at a freshly built+pushed digest.
+	// scaleFromZeroImageDefault is an all-zeros placeholder digest that is
+	// DELIBERATELY UNPULLABLE. The activation spec needs a real file-manager image
+	// that serves /api/health, so the nightly workflow MUST set SCALE_TEST_IMAGE to
+	// a freshly built+pushed, digest-pinned image. If this default is ever used the
+	// ksvc ErrImagePulls and the spec fails at "ksvc not Ready" — the
+	// operator-e2e-nightly workflow guards against that by skipping the run when no
+	// SCALE_TEST_IMAGE is provided.
+	// TODO(#39): wire a publish job that sets vars.SCALE_TEST_IMAGE to the latest
+	// file-manager digest so the nightly schedule always has a real image.
 	scaleFromZeroImageDefault = "dev.local/file-manager@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 )
 

--- a/packages/kn-next-operator/test/e2e/scale_suite_test.go
+++ b/packages/kn-next-operator/test/e2e/scale_suite_test.go
@@ -26,13 +26,18 @@ limitations under the License.
 // Both specs must NOT each `make deploy` the controller-manager — a second
 // deploy of the same release into the same namespace races the first spec's
 // AfterAll undeploy and flakes the suite. So the operator install/deploy/rollout
-// (and the matching undeploy/uninstall) live here ONCE, in the suite's
-// Before/AfterSuite, and each spec's BeforeAll/AfterAll only applies and deletes
-// its OWN namespace + NextApp CR.
+// (and the matching undeploy/uninstall) run ONCE for the whole suite, and each
+// spec's BeforeAll/AfterAll only applies and deletes its OWN namespace +
+// NextApp CR.
 //
-// This file is only compiled under the `e2e_scale` tag, so it never interferes
-// with the `e2e`-tagged Manager spec (e2e_test.go), which manages its own deploy
-// and runs in a separate `go test -tags=e2e` invocation.
+// Ginkgo allows exactly ONE BeforeSuite and ONE AfterSuite per suite, and the
+// shared e2e_suite_test.go (tag `e2e || e2e_scale`) already owns them. So this
+// file does NOT declare its own suite-setup nodes — a second BeforeSuite would
+// make Ginkgo fail the whole suite before any spec runs. Instead it exposes the
+// deploy/undeploy helpers, which the `e2e_scale`-only build-tagged hook in
+// suite_hooks.go calls from that single BeforeSuite/AfterSuite. Under the plain
+// `e2e` tag the hook is a no-op (e2e_test.go's Manager spec owns its own
+// deploy), so this never interferes with that path.
 package e2e
 
 import (
@@ -44,14 +49,6 @@ import (
 
 	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/test/utils"
 )
-
-var _ = BeforeSuite(func() {
-	deployOperatorOnce()
-})
-
-var _ = AfterSuite(func() {
-	undeployOperator()
-})
 
 // deployOperatorOnce installs the CRDs and deploys the controller-manager, then
 // waits for the rollout. Called exactly once for the whole e2e_scale suite.

--- a/packages/kn-next-operator/test/e2e/scale_suite_test.go
+++ b/packages/kn-next-operator/test/e2e/scale_suite_test.go
@@ -1,0 +1,84 @@
+//go:build e2e_scale
+// +build e2e_scale
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Shared bootstrap for the `e2e_scale` suite, which contains MULTIPLE Ordered
+// Describes that each need the operator running:
+//
+//   - scale_to_zero_cache_test.go     — A2-2 / #38 (bytecode cache survival)
+//   - scale_from_zero_test.go         — A2-3 / #39 (scale-to-zero then activate)
+//
+// Both specs must NOT each `make deploy` the controller-manager — a second
+// deploy of the same release into the same namespace races the first spec's
+// AfterAll undeploy and flakes the suite. So the operator install/deploy/rollout
+// (and the matching undeploy/uninstall) live here ONCE, in the suite's
+// Before/AfterSuite, and each spec's BeforeAll/AfterAll only applies and deletes
+// its OWN namespace + NextApp CR.
+//
+// This file is only compiled under the `e2e_scale` tag, so it never interferes
+// with the `e2e`-tagged Manager spec (e2e_test.go), which manages its own deploy
+// and runs in a separate `go test -tags=e2e` invocation.
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/AhmedElBanna80/knext/packages/kn-next-operator/test/utils"
+)
+
+var _ = BeforeSuite(func() {
+	deployOperatorOnce()
+})
+
+var _ = AfterSuite(func() {
+	undeployOperator()
+})
+
+// deployOperatorOnce installs the CRDs and deploys the controller-manager, then
+// waits for the rollout. Called exactly once for the whole e2e_scale suite.
+func deployOperatorOnce() {
+	By("installing the operator CRDs")
+	_, err := utils.Run(exec.Command("make", "install"))
+	Expect(err).NotTo(HaveOccurred(), "failed to install CRDs")
+
+	By("deploying the controller-manager")
+	_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage)))
+	Expect(err).NotTo(HaveOccurred(), "failed to deploy the controller-manager")
+
+	By("waiting for the controller-manager rollout to complete")
+	Eventually(func(g Gomega) {
+		out, err := utils.Kubectl("rollout", "status",
+			"deployment/kn-next-operator-controller-manager",
+			"-n", operatorNamespace, "--timeout=10s")
+		g.Expect(err).NotTo(HaveOccurred(), out)
+	}).Should(Succeed())
+}
+
+// undeployOperator tears down the controller-manager and CRDs. Called exactly
+// once for the whole e2e_scale suite.
+func undeployOperator() {
+	By("undeploying the controller-manager")
+	_, _ = utils.Run(exec.Command("make", "undeploy"))
+
+	By("uninstalling the operator CRDs")
+	_, _ = utils.Run(exec.Command("make", "uninstall"))
+}

--- a/packages/kn-next-operator/test/e2e/scale_to_zero_cache_test.go
+++ b/packages/kn-next-operator/test/e2e/scale_to_zero_cache_test.go
@@ -59,8 +59,6 @@ import (
 )
 
 const (
-	// operatorNamespace is where `make deploy` installs the controller-manager.
-	operatorNamespace = "kn-next-operator-system"
 	// scaleAppNamespace is where the NextApp under test is deployed.
 	scaleAppNamespace = "kn-next-scale-test"
 	// scaleAppName is the NextApp / Knative Service name under test.
@@ -76,26 +74,9 @@ var _ = Describe("ScaleToZero bytecode cache (A2-2 / #38)", Ordered, func() {
 	SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 	BeforeAll(func() {
-		// The operator MUST be running, or nothing reconciles the NextApp CR and
-		// the ksvc never becomes Ready. The shared BeforeSuite only builds + loads
-		// the manager image and installs CertManager — it does NOT deploy the
-		// manager — so the scale spec deploys it here before applying the CR.
-		By("installing the operator CRDs")
-		_, err := utils.Run(exec.Command("make", "install"))
-		Expect(err).NotTo(HaveOccurred(), "failed to install CRDs")
-
-		By("deploying the controller-manager")
-		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage)))
-		Expect(err).NotTo(HaveOccurred(), "failed to deploy the controller-manager")
-
-		By("waiting for the controller-manager rollout to complete")
-		Eventually(func(g Gomega) {
-			out, err := utils.Kubectl("rollout", "status",
-				"deployment/kn-next-operator-controller-manager",
-				"-n", operatorNamespace, "--timeout=10s")
-			g.Expect(err).NotTo(HaveOccurred(), out)
-		}).Should(Succeed())
-
+		// The operator is deployed ONCE for the whole e2e_scale suite by the
+		// shared BeforeSuite (scale_suite_test.go); this spec only manages its
+		// OWN namespace + NextApp CR so it can coexist with the #39 spec.
 		By("creating the scale-test namespace")
 		_, _ = utils.Kubectl("create", "ns", scaleAppNamespace)
 
@@ -107,12 +88,6 @@ var _ = Describe("ScaleToZero bytecode cache (A2-2 / #38)", Ordered, func() {
 	AfterAll(func() {
 		By("deleting the scale-test namespace")
 		_, _ = utils.Kubectl("delete", "ns", scaleAppNamespace, "--ignore-not-found")
-
-		By("undeploying the controller-manager")
-		_, _ = utils.Run(exec.Command("make", "undeploy"))
-
-		By("uninstalling the operator CRDs")
-		_, _ = utils.Run(exec.Command("make", "uninstall"))
 	})
 
 	It("reuses the bytecode cache across a scale-to-zero cold start", func() {
@@ -138,7 +113,7 @@ var _ = Describe("ScaleToZero bytecode cache (A2-2 / #38)", Ordered, func() {
 		_, _ = fmt.Fprintf(GinkgoWriter, "warm-up cache files: %s\n", warmupFileCount)
 
 		By("waiting for the service to scale to zero")
-		Expect(waitForScaleToZero(scaleAppNamespace, scaleAppName)).To(Succeed())
+		Expect(utils.WaitForScaleToZero(scaleAppNamespace, scaleAppName)).To(Succeed())
 
 		By("reactivating from cold and scraping the app metrics again")
 		var warmStart, coldStartFileCount string
@@ -195,17 +170,4 @@ func applyManifest(manifest string) error {
 	cmd.Stdin = strings.NewReader(manifest)
 	_, err := utils.Run(cmd)
 	return err
-}
-
-// waitForScaleToZero blocks until the Knative service has 0 Running pods.
-func waitForScaleToZero(namespace, ksvc string) error {
-	deadline := time.Now().Add(5 * time.Minute)
-	for time.Now().Before(deadline) {
-		n, err := utils.KnativeReadyPodCount(namespace, ksvc)
-		if err == nil && n == 0 {
-			return nil
-		}
-		time.Sleep(3 * time.Second)
-	}
-	return fmt.Errorf("service %s/%s did not scale to zero within timeout", namespace, ksvc)
 }

--- a/packages/kn-next-operator/test/e2e/suite_hooks_e2e_test.go
+++ b/packages/kn-next-operator/test/e2e/suite_hooks_e2e_test.go
@@ -1,0 +1,30 @@
+//go:build e2e && !e2e_scale
+// +build e2e,!e2e_scale
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Plain `e2e` variant of the suite-setup hook: a no-op. Under the e2e tag the
+// Manager spec (e2e_test.go) deploys and undeploys the operator inside its own
+// BeforeAll/AfterAll, so the suite-level hook must NOT also deploy it. The
+// e2e_scale variant lives in suite_hooks_scale_test.go.
+package e2e
+
+// extraSuiteSetup is a no-op under the plain e2e tag.
+func extraSuiteSetup() {}
+
+// extraSuiteTeardown is a no-op under the plain e2e tag.
+func extraSuiteTeardown() {}

--- a/packages/kn-next-operator/test/e2e/suite_hooks_scale_test.go
+++ b/packages/kn-next-operator/test/e2e/suite_hooks_scale_test.go
@@ -1,0 +1,31 @@
+//go:build e2e_scale
+// +build e2e_scale
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// e2e_scale variant of the suite-setup hook. Ginkgo permits only one BeforeSuite
+// / AfterSuite per suite, and the shared e2e_suite_test.go owns them; these hooks
+// let the e2e_scale suite extend that single pair to deploy the operator ONCE for
+// the whole suite (see scale_suite_test.go). The matching e2e variant
+// (suite_hooks_e2e_test.go) is a no-op because e2e_test.go deploys per-Describe.
+package e2e
+
+// extraSuiteSetup deploys the operator once for the e2e_scale suite.
+func extraSuiteSetup() { deployOperatorOnce() }
+
+// extraSuiteTeardown undeploys the operator once at the end of the e2e_scale suite.
+func extraSuiteTeardown() { undeployOperator() }

--- a/packages/kn-next-operator/test/utils/utils.go
+++ b/packages/kn-next-operator/test/utils/utils.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive,staticcheck
 )
@@ -200,6 +202,79 @@ func KnativeReadyPodCount(namespace, ksvc string) (int, error) {
 		return 0, err
 	}
 	return len(GetNonEmptyLines(out)), nil
+}
+
+// WaitForScaleToZero blocks until the Knative service has 0 Running pods, or
+// returns an error after a 5-minute timeout. Promoted out of #38's spec
+// (was a local `waitForScaleToZero`) so the #39 scale-from-zero regression can
+// reuse it. It only wraps KnativeReadyPodCount.
+func WaitForScaleToZero(namespace, ksvc string) error {
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		n, err := KnativeReadyPodCount(namespace, ksvc)
+		if err == nil && n == 0 {
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("service %s/%s did not scale to zero within timeout", namespace, ksvc)
+}
+
+// WaitForScaleFromZero blocks until the Knative service has at least one Running
+// pod (i.e. the activator has woken a replica), or returns an error after a
+// 5-minute timeout. Used by the #39 activation path to assert a scaled-to-zero
+// service comes back up on demand.
+func WaitForScaleFromZero(namespace, ksvc string) error {
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		n, err := KnativeReadyPodCount(namespace, ksvc)
+		if err == nil && n >= 1 {
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("service %s/%s did not scale up from zero within timeout", namespace, ksvc)
+}
+
+// ActivateAndGet sends a GET to the cluster-local Knative service at the given
+// path from an ephemeral in-cluster curl pod, and returns the HTTP status code
+// and response body. This is the #39 activation primitive: hitting a
+// scaled-to-zero service routes through the Knative activator, which wakes a
+// pod and proxies the request once it is Ready. Modeled on ScrapeAppMetrics.
+func ActivateAndGet(namespace, ksvc, path string) (int, string, error) {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local%s", ksvc, namespace, path)
+	podName := fmt.Sprintf("activate-%s", ksvc)
+	// Best-effort cleanup of any prior activation pod.
+	_, _ = Kubectl("delete", "pod", podName, "-n", namespace, "--ignore-not-found")
+	// `-w '\n%{http_code}'` appends the status code on its own trailing line so we
+	// can split it off the body without a second request. --max-time covers the
+	// cold-start wake (activator hold) plus the app response.
+	out, err := Kubectl("run", podName,
+		"-n", namespace,
+		"--restart=Never",
+		"--rm", "-i",
+		"--image=curlimages/curl:8.11.1",
+		"--command", "--",
+		"curl", "-sS", "--max-time", "120", "-w", "\\n%{http_code}", url,
+	)
+	if err != nil {
+		return 0, out, err
+	}
+	// The status code is the last non-empty line; everything before it is the body.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) == 0 {
+		return 0, out, fmt.Errorf("empty response from %s", url)
+	}
+	codeStr := strings.TrimSpace(lines[len(lines)-1])
+	code, convErr := strconv.Atoi(codeStr)
+	if convErr != nil {
+		return 0, out, fmt.Errorf("could not parse HTTP status %q from response: %w", codeStr, convErr)
+	}
+	body := strings.Join(lines[:len(lines)-1], "\n")
+	return code, body, nil
 }
 
 // ScrapeAppMetrics curls the app's own `/api/metrics` route (port 3000 inside

--- a/packages/kn-next-operator/test/utils/utils.go
+++ b/packages/kn-next-operator/test/utils/utils.go
@@ -249,31 +249,41 @@ func ActivateAndGet(namespace, ksvc, path string) (int, string, error) {
 	podName := fmt.Sprintf("activate-%s", ksvc)
 	// Best-effort cleanup of any prior activation pod.
 	_, _ = Kubectl("delete", "pod", podName, "-n", namespace, "--ignore-not-found")
-	// `-w '\n%{http_code}'` appends the status code on its own trailing line so we
-	// can split it off the body without a second request. --max-time covers the
-	// cold-start wake (activator hold) plus the app response.
+	// We cannot rely on "the status code is the last line": utils.Run uses
+	// CombinedOutput, so `kubectl run --rm` merges its own `pod "..." deleted`
+	// notice (stderr) into the captured output, which would otherwise be parsed
+	// as the HTTP code. Instead, curl's `-w` wraps the code in unique sentinels
+	// (KNHTTP<code>KNEND) that we extract by marker, ignoring any surrounding
+	// kubectl noise — the same robustness ScrapeAppMetricValue relies on.
+	const codePrefix, codeSuffix = "KNHTTP", "KNEND"
 	out, err := Kubectl("run", podName,
 		"-n", namespace,
 		"--restart=Never",
 		"--rm", "-i",
 		"--image=curlimages/curl:8.11.1",
 		"--command", "--",
-		"curl", "-sS", "--max-time", "120", "-w", "\\n%{http_code}", url,
+		"curl", "-sS", "--max-time", "120",
+		"-w", fmt.Sprintf("\\n%s%%{http_code}%s", codePrefix, codeSuffix), url,
 	)
 	if err != nil {
 		return 0, out, err
 	}
-	// The status code is the last non-empty line; everything before it is the body.
-	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
-	if len(lines) == 0 {
-		return 0, out, fmt.Errorf("empty response from %s", url)
+	start := strings.LastIndex(out, codePrefix)
+	if start < 0 {
+		return 0, out, fmt.Errorf("no HTTP status marker in response from %s: %q", url, out)
 	}
-	codeStr := strings.TrimSpace(lines[len(lines)-1])
+	rest := out[start+len(codePrefix):]
+	end := strings.Index(rest, codeSuffix)
+	if end < 0 {
+		return 0, out, fmt.Errorf("truncated HTTP status marker in response from %s: %q", url, out)
+	}
+	codeStr := strings.TrimSpace(rest[:end])
 	code, convErr := strconv.Atoi(codeStr)
 	if convErr != nil {
 		return 0, out, fmt.Errorf("could not parse HTTP status %q from response: %w", codeStr, convErr)
 	}
-	body := strings.Join(lines[:len(lines)-1], "\n")
+	// The body is everything before the `\n` that precedes the status marker.
+	body := strings.TrimRight(out[:start], "\n")
 	return code, body, nil
 }
 


### PR DESCRIPTION
Closes #39.

An e2e regression for **scale-to-zero → activation**: a `minScale:0` app reaches **0 replicas** when idle, then a request through the Knative **activator** wakes a pod and returns 200. Distinct from #38 (cache survival) — this locks the *activation* path. Layered like #38 (honest about PR-CI vs nightly):

**Layer 1 — per-PR envtest gate (deterministic):** `reconcile_output_test.go` asserts the operator renders `autoscaling.knative.dev/min-scale: "0"` + `max-scale: "1"` for a scale-to-zero NextApp — the app is genuinely scale-to-zero-eligible. Non-tautological (default max-scale is `"10"`; the test passes `MaxScale:1` and asserts `"1"`).

**Layer 2 — nightly/dispatch `e2e_scale` spec:** `scale_from_zero_test.go` — deploy a minimal NextApp (minScale:0, **no** PVC/bytecode, so it's decoupled from #59) → wait Ready → `WaitForScaleToZero` → `ActivateAndGet("/api/health")` → assert a pod scaled up (`KnativeReadyPodCount >= 1`) **and** HTTP 200 with the `/api/health` body marker. Runs only in the existing `operator-e2e-nightly.yml` (one job now covers #38 + #39), `continue-on-error`.

**Reuse, not duplication:** promoted `WaitForScaleToZero` from #38 into `test/utils` (deleted #38's local copy); added `WaitForScaleFromZero` + `ActivateAndGet`. Refactored the suite so the operator is deployed **once** in a single shared `BeforeSuite` and each spec manages only its own namespace.

**Guard pass caught two real bugs before review:** a duplicate `BeforeSuite`/`AfterSuite` that Ginkgo rejects at tree-construction (would have killed the *entire* `e2e_scale` suite — both #38 and #39), and an `ActivateAndGet` status parse that mis-read `kubectl run`'s teardown notice as the HTTP code. Both fixed (sentinel-wrapped status extraction).

**Verified:** `make test` (Layer 1 envtest) GREEN · `go build` clean · `go vet -tags e2e_scale` **and** `-tags e2e` both compile · `e2e_scale` dry-run OK · nightly YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
