### PR TITLE
docs: deferred follow-up ADRs (rollback, RUM bounded-aggregator exception, async ISR revalidation) + #98 predicate note

### DIFF
--- a/docs/adr/0003-transport-connect-buf.md
+++ b/docs/adr/0003-transport-connect-buf.md
@@ -47,6 +47,10 @@ HTTP-annotation plumbing and a transcoding layer, and has weaker TS ergonomics.
 
 ## Revalidation status (ISR-over-Kafka routing — DEFERRED, #95)
 
+> **Promoted to [ADR-0016](0016-async-isr-revalidation.md).** This addendum is retained for history;
+> the async-ISR-revalidation decision (the `provisionKafkaSource` opt-in + `RevalidationDeferred`
+> condition) now lives in its own ADR — edit ADR-0016 going forward.
+
 The Kafka→revalidator routing this ADR's family describes (a domain event lands on Kafka →
 a `{app}-revalidator` service consumes it → it calls `revalidateTag()` to invalidate every pod's
 Redis-backed cache) is **deferred / build-later**. The `{app}-revalidator` consumer service has

--- a/docs/adr/0008-app-namespaced-assets-and-deletion-finalizer.md
+++ b/docs/adr/0008-app-namespaced-assets-and-deletion-finalizer.md
@@ -53,6 +53,14 @@ violate data sovereignty (a zone must never touch another zone's data).
   providers and non-Redis caches no-op with a logged warning until implemented.
 - The deletion branch runs **before** spec validation, so even an invalid-image `NextApp` can still
   be deleted (no wedge path).
+- **Reconcile-trigger semantics (#98).** The `For(&NextApp{})` watch carries a
+  `GenerationChangedPredicate`, so a status-only write does not re-enqueue (this killed a ~45/s
+  idle reconcile hot-loop). The trade-off: an **annotation/label-only** edit to a `NextApp` (which
+  does not bump `metadata.generation`) will **not** re-reconcile — including the finalizer-bearing
+  pass. This is acceptable because the reconciler (and this finalizer) key off `spec` and deletion
+  timestamps, not metadata; the four `Owns(...)` watches stay unfiltered so owned-resource drift
+  still reconciles. If a future field is ever read from metadata, switch to
+  `predicate.Or(GenerationChangedPredicate{}, AnnotationChangedPredicate{})`.
 
 ## Action items
 - (Done in #74) finalizer + scoped `ExternalCleaner` + app-namespaced uploads + CLI CR-only teardown.

--- a/docs/adr/0014-rollback-traffic-split.md
+++ b/docs/adr/0014-rollback-traffic-split.md
@@ -1,0 +1,57 @@
+# ADR-0014: Rollback via Knative revision traffic split
+
+- Status: Accepted
+- Date: 2026-06-23
+- Deciders: knext architect
+- Related: ADR-0001 (operator = single source of truth), ADR-0011 (build-id-versioned assets +
+  retention GC), ADR-0013 (preview lifecycle), issue #92 (rollback), issue #93 (skew protection)
+
+## Context
+
+Every `kn-next deploy` produces a new Knative **Revision**; Knative can already split traffic across
+revisions. We needed a first-class **rollback** affordance (and, as a near-free extension, canary)
+without violating ADR-0001 — the operator must remain the single writer of cluster state, and the
+CLI may only emit intent. The question was: where does the traffic-target intent live, and how does
+the operator render it?
+
+## Decision
+
+A traffic target is a declarative field on the `NextApp` CR, and the operator renders it into the
+Knative Service's `spec.traffic`:
+
+- **CR field** `spec.traffic` (`TrafficSpec { revisionName, canaryPercent }`):
+  - unset / empty `revisionName` → Knative default (100% latest-ready) — byte-identical to pre-#92.
+  - `revisionName` set, `canaryPercent` 0 → 100% pinned to that revision (a full rollback).
+  - `revisionName` set, `canaryPercent` p∈1..99 → `(100−p)%` pinned + `p%` latest-ready (canary).
+- **CLI** `kn-next rollback <app> [--to <revision>] [--canary <n>]` patches **only** the `NextApp`
+  CR (`kubectl patch nextapp … --type merge`), never the ksvc/Route directly. The operator's
+  `buildTrafficTargets` is the sole writer of `ksvc.spec.traffic`.
+- **Status** `NextApp.status.currentTraffic` mirrors the observed live split (concrete revision
+  names + percents) so `kubectl get nextapp -o yaml` shows what is actually serving.
+
+This is a thin, declarative wrapper over a native Knative primitive — no new runtime, no
+blue/green controller, no out-of-band mutation.
+
+## Options considered
+
+| Option | Verdict | Why |
+|---|---|---|
+| **CR `spec.traffic` → operator renders `ksvc.spec.traffic` (chosen)** | Accepted | ADR-0001-clean (CLI emits intent only); uses Knative's own traffic primitive; canary falls out for free; status reflects reality |
+| CLI patches `ksvc.spec.traffic` directly | Rejected | Second writer of deployment shape — direct ADR-0001 violation |
+| A separate blue/green controller | Rejected | New runtime + state for something Knative already does; scope drift |
+
+## Consequences
+
+- Rollback and canary are one CR field and one CLI verb; no new control loop.
+- Pinning an old revision interacts with **skew protection** (ADR-0011): a rolled-back/canary
+  revision must keep serving its own assets, so the build-id-aware GC treats any revision in
+  `status.currentTraffic` as live and never reaps its assets.
+- A pinned `revisionName` that Knative has garbage-collected yields an unresolvable target
+  (`RoutesReady=False`); the operator does not yet surface this as a `Degraded` condition — a known
+  follow-up (the reconciler could detect the unresolvable-revision case and mark `Degraded`).
+
+## Action items
+
+- [x] `TrafficSpec` + `status.currentTraffic` on the CRD; `buildTrafficTargets` in the reconciler.
+- [x] `kn-next rollback` CLI (CR-only patch, shell:false argv).
+- [ ] Surface an unresolvable pinned revision as `Degraded` in status (follow-up).

--- a/docs/adr/0015-bounded-aggregator-ingest-exception.md
+++ b/docs/adr/0015-bounded-aggregator-ingest-exception.md
@@ -1,0 +1,60 @@
+# ADR-0015: The bounded-aggregator exception to "no unauthenticated mutating endpoint"
+
+- Status: Accepted
+- Date: 2026-06-23
+- Deciders: knext architect, system designer
+- Related: ADR-0001 (operator = single source of truth), `.claude/rules/security.md`,
+  `docs/security/mutating-endpoints.md`, issue #94 (RUM), issue #90 (NetworkPolicy)
+
+## Context
+
+knext's hard security rule is **no unauthenticated mutating endpoints** — every state-changing
+route requires a signed token and/or an internal-only `NetworkPolicy`. The RUM feature (#94) added
+`POST /api/rum`: a browser beacon that reports Web Vitals. It **mutates** state (it `observe()`s
+Prometheus histograms), yet by nature it is sent by anonymous browsers and **cannot** carry the
+`CACHE_INVALIDATE_TOKEN` Bearer secret (that would leak the secret to every client). This is a
+genuine, recurring category — analytics/telemetry beacons — and we needed a recorded rule for when
+such an endpoint is acceptable, rather than re-arguing it each time.
+
+## Decision
+
+A browser-facing mutating endpoint is acceptable **without a Bearer token** only when it is a
+**bounded aggregator** — it must satisfy *all four* neutering conditions, and the audit
+(`docs/security/mutating-endpoints.md`) must record it as an explicit, justified exception:
+
+1. **Not a write primitive.** The handler can ONLY `observe()`/increment a fixed set of
+   pre-declared metrics. It cannot create series, set arbitrary values, write storage, revalidate
+   cache, or perform any general state mutation.
+2. **Server-enforced bounded label cardinality.** Every label comes from a closed, server-side
+   allow-list; any client-supplied free text (e.g. a URL path) is mapped to a fixed **template** or
+   an `other` bucket. No user/session/IP/raw-URL label. This caps the series count at a small
+   constant and prevents a cardinality-DoS.
+3. **Rate-limited + size-capped + shape-validated.** An in-process rate limiter, a hard request-body
+   cap, and strict schema validation; malformed/oversized/over-rate requests are rejected.
+4. **Network-isolated, same-origin.** Reachable only as broadly as the app already is (the
+   operator's default-on `NetworkPolicy`, #90) — it adds no new external surface.
+
+`POST /api/rum` satisfies all four and is the reference implementation.
+
+## Options considered
+
+| Option | Verdict | Why |
+|---|---|---|
+| **Bounded-aggregator exception, 4 conditions, audited (chosen)** | Accepted | Lets unauthenticatable telemetry exist while bounding blast radius to "skew percentiles within fixed buckets"; honest and recorded |
+| Require a Bearer token on the beacon | Rejected | Impossible — leaks the secret to every browser |
+| A separate authenticated server-side collector | Rejected | Heavier; the beacon still needs an unauthenticated public ingress somewhere |
+
+## Consequences
+
+- The exception is **narrow and testable**: the four conditions are an explicit checklist a reviewer
+  applies to any future browser-facing mutating endpoint before it ships.
+- It is **not** a general loophole — anything that can create series, write storage, or carry
+  unbounded labels is NOT covered and still requires auth.
+- The audit doc remains the source of truth; a CI guard (every mutating route under `apps/*/src/app/api`
+  must carry `isAuthorized` or be a listed exception) keeps it honest.
+
+## Action items
+
+- [x] `/api/rum` implemented as a bounded aggregator (validate / rate-limit / closed allow-lists).
+- [x] Recorded as a justified exception in `docs/security/mutating-endpoints.md`.
+- [ ] Wire the CI guard that fails a new unlisted mutating route lacking `isAuthorized`.

--- a/docs/adr/0016-async-isr-revalidation.md
+++ b/docs/adr/0016-async-isr-revalidation.md
@@ -1,0 +1,61 @@
+# ADR-0016: Asynchronous ISR revalidation & the Kafka queue (deferred consumer)
+
+- Status: Accepted
+- Date: 2026-06-23
+- Deciders: knext architect
+- Related: ADR-0001 (operator = single source of truth), ADR-0003 (Connect + buf transport),
+  ADR-0004 (BackendService CRD), issue #95 (dangling Kafka revalidator sink), closed PR #27
+
+## Context
+
+This decision previously lived as a "Revalidation status (DEFERRED, #95)" addendum bolted onto
+ADR-0003 (a *transport* ADR). It is a distinct, user-facing decision — `spec.revalidation` is now a
+CRD surface and the docs reference it — so it is promoted to its own ADR.
+
+knext's ISR / data cache is **Redis** (`cache.provider: redis`, the `cache-handler.js`):
+`revalidateTag` / `revalidatePath` delete shared Redis keys, so invalidation is **fleet-wide**
+across all pods/zones already — no cross-pod fan-out is needed for correctness within an app. The
+open question is cross-**zone** / event-driven revalidation: the operator could provision a Knative
+`KafkaSource` whose sink delivers domain events to an `{app}-revalidator` consumer. That consumer
+was never built — provisioning the KafkaSource produced a **dangling sink** pointing at a service
+that does not exist (#95).
+
+## Decision
+
+**Gate the KafkaSource behind an explicit opt-in; default it OFF; keep the `{app}-revalidator`
+consumer design-now / build-later.**
+
+- `spec.revalidation.provisionKafkaSource` (`*bool`, default nil/false) — only when `true` does the
+  operator provision the `KafkaSource`. The default reconcile creates **no** dangling infra.
+- When `revalidation.queue == "kafka"` but the opt-in is unset, the operator surfaces a non-fatal
+  `RevalidationDeferred` status condition (reason `ConsumerNotProvisioned`) and keeps `Ready=True` —
+  the deferral is observable, not silent.
+- Enabling the opt-in asserts the operator **deploys its own** `{app}-revalidator` consumer; that
+  consumer, when built, will be a cluster-local Knative service (ADR-0004 posture) with an
+  authenticated CloudEvent → `revalidateTag()` ingress (it is a mutating surface — ADR-0015 / the
+  no-unauthenticated-mutating-endpoint rule applies).
+
+## Options considered
+
+| Option | Verdict | Why |
+|---|---|---|
+| Build the `{app}-revalidator` consumer now | Rejected | Large new authenticated CloudEvent ingress + service, depends on the shelved routing layer (PR #27); premature before Tier-A correctness |
+| **Gate provisioning behind an opt-in; defer the consumer (chosen)** | Accepted | Removes the dangling sink now with a small, fully-tested change; the consumer is a clean opt-in follow-up; deferral is observable |
+| Drop the Kafka path entirely | Rejected | Loses the cross-zone event mechanism the SCS model needs long-term |
+
+## Consequences
+
+- Default deploys no longer create a `KafkaSource` with a sink pointing nowhere.
+- **Backward-compat (intentional):** an existing CR with `revalidation.queue: kafka` and no opt-in
+  stops getting a (dangling) KafkaSource and instead surfaces `RevalidationDeferred`. Re-enable with
+  one field once a consumer is deployed.
+- The cross-zone async revalidation story (SCS domain events) remains designed-but-unbuilt; this ADR
+  is the record of where that line sits.
+
+## Action items
+
+- [x] `provisionKafkaSource` opt-in + `RevalidationDeferred` condition in the reconciler (#95/#99).
+- [x] Docs (`docs/operator/kafka-eventing.md`, the docs-site operator page) state the consumer is
+  build-later.
+- [ ] Build the cluster-local, authenticated `{app}-revalidator` consumer (after Tier-A correctness;
+  re-evaluate whether closed PR #27 is salvageable first).


### PR DESCRIPTION
Records the decision-record debt flagged by sign-offs across this session. **Decision records only — no code change** (every decision is already shipped).

- ADR-0014 — Rollback via Knative revision traffic split (#92): spec.traffic → operator renders ksvc.spec.traffic; CLI emits CR-only (ADR-0001); canary; status.currentTraffic. (Architect flagged on PR #97.)
- ADR-0015 — Bounded-aggregator ingest exception (#94): the four conditions a browser-facing mutating endpoint must meet to skip the Bearer token (not-a-write-primitive, bounded cardinality, rate/size/shape limits, network isolation). (Both #100 sign-offs flagged it.)
- ADR-0016 — Async ISR revalidation & the Kafka queue (#95): promotes the DEFERRED addendum out of ADR-0003 into its own record; provisionKafkaSource opt-in + RevalidationDeferred; consumer design-now/build-later.
- ADR-0008 +note: the #98 GenerationChangedPredicate reconcile-trigger trade-off. ADR-0003 gets a pointer to 0016.

docs/adr/ only — no CRD/code/test changes.