### PR TITLE
PK1 — Build the full @knext/core library surface to dist (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,13 @@ jobs:
 
       # @knext/core ships only dist/ and its exports resolve to ./dist/* (#114).
       # The publish-surface test asserts every exports subpath exists in dist, so
-      # core MUST be built before vitest runs (same convention as the other jobs).
+      # core MUST be built before vitest runs. @knext/lib must be built first —
+      # core's dts build imports @knext/lib/clients types (next-adapter.ts:122),
+      # so without lib's dist the core build hard-fails (TS2307). Same lib→core
+      # order as the compat-smoke and bytecode jobs.
+      - name: Build @knext/lib
+        run: pnpm --filter @knext/lib build
+
       - name: Build @knext/core
         run: pnpm --filter @knext/core build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,16 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Run Biome lint & format check
         run: pnpm run lint
-      
+
+      # @knext/core ships only dist/ and its exports resolve to ./dist/* (#114).
+      # The publish-surface test asserts every exports subpath exists in dist, so
+      # core MUST be built before vitest runs (same convention as the other jobs).
+      - name: Build @knext/core
+        run: pnpm --filter @knext/core build
+
       - name: Run tests
         run: pnpm exec vitest run --coverage
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # @knext/lib ships only dist/ — it MUST be built before the app.
+      # @knext/lib and @knext/core both ship only dist/ — they MUST be built
+      # before the app. file-manager imports @knext/core/adapters/otel-config and
+      # the KnativeNextConfig type, and @knext/core's exports now resolve to
+      # ./dist/* (#114), so a missing core build breaks `next build`.
       - name: Build @knext/lib
         run: pnpm --filter @knext/lib build
+
+      - name: Build @knext/core
+        run: pnpm --filter @knext/core build
 
       - name: Build file-manager via adapter
         run: pnpm --filter file-manager build
@@ -110,9 +116,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # @knext/lib ships only dist/ — it MUST be built before the app.
+      # @knext/lib and @knext/core both ship only dist/ — they MUST be built
+      # before the app. @knext/core's exports now resolve to ./dist/* (#114), and
+      # file-manager imports it, so a missing core build breaks `next build`.
       - name: Build @knext/lib
         run: pnpm --filter @knext/lib build
+
+      - name: Build @knext/core
+        run: pnpm --filter @knext/core build
 
       - name: Build file-manager standalone (next build --webpack)
         run: pnpm --filter file-manager build

--- a/apps/file-manager/Dockerfile
+++ b/apps/file-manager/Dockerfile
@@ -10,6 +10,11 @@ RUN pnpm install --frozen-lockfile
 # SEPARATE step so its dist/ is fully emitted before `next build` resolves it.
 # (A combined recursive build can race the app's build ahead of the lib's emit.)
 RUN pnpm --filter "@knext/lib" build
+# @knext/core also ships only dist/ and its exports resolve to ./dist/* (#114);
+# file-manager imports @knext/core (adapter + KnativeNextConfig), so core must be
+# built (after lib, whose types core's build needs) BEFORE `next build` resolves
+# it from dist. Order: lib → core → file-manager.
+RUN pnpm --filter "@knext/core" build
 RUN pnpm --filter file-manager build
 
 # Stage 2: Lean production image using Node.js standalone output

--- a/packages/kn-next/LICENSE
+++ b/packages/kn-next/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 The knext Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/kn-next/README.md
+++ b/packages/kn-next/README.md
@@ -1,0 +1,41 @@
+# @knext/core
+
+The `kn-next` CLI and the official Next.js deployment adapter for running
+Next.js on **Knative** with **scale-to-zero**.
+
+`@knext/core` gives you two things:
+
+- **`kn-next` CLI** — build your Next.js app, publish the container image, and
+  deploy it to a Knative cluster.
+- **The Next.js adapter** — wires your app into Knative's scale-to-zero runtime
+  using the official Next.js Deployment Adapter API (`output: 'standalone'`).
+
+## Install
+
+```bash
+npm i @knext/core
+# or run the CLI directly
+npx kn-next --help
+```
+
+## Usage
+
+Deploy your Next.js app:
+
+```bash
+npx kn-next deploy
+```
+
+Reference the adapter and config types from your `next.config` / `kn-next.config`:
+
+```ts
+import type { KnativeNextConfig } from '@knext/core';
+```
+
+## Documentation
+
+Full guides and configuration reference: <https://knext.dev>
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/kn-next/package.json
+++ b/packages/kn-next/package.json
@@ -3,22 +3,59 @@
   "version": "0.1.0",
   "description": "Knative Next.js configuration and CLI",
   "type": "module",
-  "main": "./src/config.ts",
-  "types": "./src/config.ts",
+  "main": "./dist/config.js",
+  "module": "./dist/config.js",
+  "types": "./dist/config.d.ts",
   "bin": {
     "kn-next": "./dist/cli/kn-next.js"
   },
   "exports": {
-    ".": "./src/config.ts",
-    "./loader": "./src/loader.ts",
-    "./adapter": "./src/adapters/next-adapter.ts",
-    "./adapters/next-adapter": "./src/adapters/next-adapter.ts",
-    "./adapters/node-server": "./src/adapters/node-server.ts",
-    "./adapters/cache-handler": "./src/adapters/cache-handler.js",
-    "./adapters/otel-config": "./src/adapters/otel-config.ts",
-    "./utils/logger": "./src/utils/logger.ts",
-    "./cli/validate": "./src/cli/validate.ts",
-    "./cli/shared": "./src/cli/shared.ts"
+    ".": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js",
+      "default": "./dist/config.js"
+    },
+    "./loader": {
+      "types": "./dist/loader.d.ts",
+      "import": "./dist/loader.js",
+      "default": "./dist/loader.js"
+    },
+    "./adapter": {
+      "types": "./dist/adapters/next-adapter.d.ts",
+      "import": "./dist/adapters/next-adapter.js",
+      "default": "./dist/adapters/next-adapter.js"
+    },
+    "./adapters/next-adapter": {
+      "types": "./dist/adapters/next-adapter.d.ts",
+      "import": "./dist/adapters/next-adapter.js",
+      "default": "./dist/adapters/next-adapter.js"
+    },
+    "./adapters/node-server": {
+      "types": "./dist/adapters/node-server.d.ts",
+      "import": "./dist/adapters/node-server.js",
+      "default": "./dist/adapters/node-server.js"
+    },
+    "./adapters/cache-handler": "./dist/adapters/cache-handler.js",
+    "./adapters/otel-config": {
+      "types": "./dist/adapters/otel-config.d.ts",
+      "import": "./dist/adapters/otel-config.js",
+      "default": "./dist/adapters/otel-config.js"
+    },
+    "./utils/logger": {
+      "types": "./dist/utils/logger.d.ts",
+      "import": "./dist/utils/logger.js",
+      "default": "./dist/utils/logger.js"
+    },
+    "./cli/validate": {
+      "types": "./dist/cli/validate.d.ts",
+      "import": "./dist/cli/validate.js",
+      "default": "./dist/cli/validate.js"
+    },
+    "./cli/shared": {
+      "types": "./dist/cli/shared.d.ts",
+      "import": "./dist/cli/shared.js",
+      "default": "./dist/cli/shared.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -31,7 +68,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "files": [
-    "src",
     "dist"
   ],
   "keywords": [

--- a/packages/kn-next/src/__tests__/publish-surface.test.ts
+++ b/packages/kn-next/src/__tests__/publish-surface.test.ts
@@ -1,0 +1,134 @@
+/**
+ * PK1 (#114) — Publish-surface packaging correctness for @knext/core.
+ *
+ * The package historically advertised its ENTIRE library surface as raw
+ * TypeScript (`main`/`types` = ./src/config.ts, every `exports` subpath →
+ * ./src/*.ts), while `tsup` only built the CLI entries. On plain Node an app
+ * importing `@knext/core/adapter` (or the `KnativeNextConfig` type) resolved to
+ * a `.ts` file Node cannot load.
+ *
+ * These tests encode the acceptance criteria:
+ *  - No `main`/`types`/`exports` entry references `./src/*.ts`; all point at dist.
+ *  - Every `exports` subpath target exists in the built `dist/` output.
+ *  - The CLI bin still points at ./dist/cli/kn-next.js.
+ *
+ * The dist-existence assertions require a prior `tsup` build. They are written
+ * RED-first: with only the CLI entries built, the library targets are missing.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(__dirname, "../..");
+
+// biome-ignore lint/suspicious/noExplicitAny: reading arbitrary package.json shape
+const pkg: any = require(resolve(pkgDir, "package.json"));
+
+/** Collect every file path referenced by main/types/exports. */
+function exportTargets(): string[] {
+    const targets: string[] = [];
+    if (typeof pkg.main === "string") targets.push(pkg.main);
+    if (typeof pkg.types === "string") targets.push(pkg.types);
+    if (typeof pkg.module === "string") targets.push(pkg.module);
+    for (const value of Object.values(pkg.exports ?? {})) {
+        if (typeof value === "string") {
+            targets.push(value);
+        } else if (value && typeof value === "object") {
+            // conditional exports ({ import, require, types, default })
+            for (const cond of Object.values(
+                value as Record<string, unknown>,
+            )) {
+                if (typeof cond === "string") targets.push(cond);
+            }
+        }
+    }
+    return targets;
+}
+
+describe("PK1: @knext/core publish surface", () => {
+    it("main and types point at compiled dist, never raw src/*.ts", () => {
+        expect(pkg.main).toMatch(/^\.\/dist\//);
+        expect(pkg.types).toMatch(/^\.\/dist\//);
+        expect(pkg.main).not.toMatch(/\.ts$/);
+        expect(pkg.types).toMatch(/\.d\.ts$/);
+    });
+
+    it("no main/types/exports entry references ./src/*.ts", () => {
+        for (const target of exportTargets()) {
+            expect(
+                target,
+                `${target} must not be a raw src/*.ts file`,
+            ).not.toMatch(/^\.\/src\/.*\.ts$/);
+            expect(target, `${target} must resolve under ./dist/`).toMatch(
+                /^\.\/dist\//,
+            );
+        }
+    });
+
+    it("declares every library subpath the example app and CLI import", () => {
+        const exp = pkg.exports ?? {};
+        for (const subpath of [
+            ".",
+            "./loader",
+            "./adapter",
+            "./adapters/next-adapter",
+            "./adapters/node-server",
+            "./adapters/cache-handler",
+            "./adapters/otel-config",
+            "./utils/logger",
+            "./cli/validate",
+            "./cli/shared",
+        ]) {
+            expect(exp, `exports must declare ${subpath}`).toHaveProperty(
+                subpath,
+            );
+        }
+    });
+
+    it("ships dist (not src) in the published files list", () => {
+        expect(pkg.files).toContain("dist");
+        expect(pkg.files).not.toContain("src");
+    });
+
+    it("keeps the CLI bin pointed at the bundled dist entry", () => {
+        expect(pkg.bin["kn-next"]).toBe("./dist/cli/kn-next.js");
+    });
+
+    // --- Build-output resolution (requires `tsup` to have run) -------------
+    it("every exports subpath resolves to a file present in dist", () => {
+        for (const target of exportTargets()) {
+            const abs = resolve(pkgDir, target);
+            expect(existsSync(abs), `missing built output: ${target}`).toBe(
+                true,
+            );
+        }
+    });
+
+    it("emits a .d.ts for each TypeScript-typed subpath", () => {
+        const typed = Object.entries(pkg.exports ?? {})
+            .filter(([sub]) => sub !== "./adapters/cache-handler")
+            .map(([, value]) =>
+                typeof value === "string"
+                    ? value
+                    : (value as Record<string, string>).types,
+            )
+            .filter((v): v is string => typeof v === "string");
+        // At minimum the root export must carry types as a .d.ts in dist.
+        const rootTypes =
+            typeof pkg.exports?.["."] === "string"
+                ? pkg.types
+                : (pkg.exports?.["."] as Record<string, string>)?.types;
+        expect(rootTypes ?? pkg.types).toMatch(/\.d\.ts$/);
+        for (const dts of typed) {
+            if (dts.endsWith(".d.ts")) {
+                expect(
+                    existsSync(resolve(pkgDir, dts)),
+                    `missing types output: ${dts}`,
+                ).toBe(true);
+            }
+        }
+    });
+});

--- a/packages/kn-next/tsup.config.ts
+++ b/packages/kn-next/tsup.config.ts
@@ -1,18 +1,25 @@
 import { defineConfig } from 'tsup';
 
 /**
- * tsup build for the kn-next CLI (issue #68).
+ * tsup build for the kn-next CLI AND the @knext/core library surface (#68, #114).
  *
- * Produces runnable, Node-only JS for the three CLI entries so an outside user
- * with no Bun installed can `npx kn-next`. The `bin.kn-next` in package.json
- * points at the bundled `dist/cli/kn-next.js` (the deploy entry — unchanged
- * behavior; deploy is what `kn-next` has always run).
+ * Produces runnable, Node-only JS for the CLI entries so an outside user with no
+ * Bun installed can `npx kn-next`. The `bin.kn-next` in package.json points at
+ * the bundled `dist/cli/kn-next.js` (the deploy entry — unchanged behavior).
+ *
+ * PK1 (#114): the package also publishes a LIBRARY surface that apps import on
+ * plain Node — config (`KnativeNextConfig`), the official Next.js adapter,
+ * node-server, cache-handler, otel-config, loader, and the logger. These were
+ * previously advertised as raw `./src/*.ts` with no dist output, breaking any
+ * consumer on Node. They are now built here so every `exports` subpath resolves
+ * to compiled JS + `.d.ts` (the `.js` cache-handler is untyped, so no `.d.ts`).
  *
  * Runtime + workspace deps are EXTERNALIZED so they resolve from the published
  * package's own `dependencies` at install time rather than being inlined.
  */
 export default defineConfig({
   entry: {
+    // --- CLI entries -----------------------------------------------------
     // dist/cli/kn-next.js — the bin (deploy entry)
     'cli/kn-next': 'src/cli/deploy.ts',
     // also ship runnable build/cleanup/rollback entries
@@ -23,6 +30,41 @@ export default defineConfig({
     'cli/preview': 'src/cli/preview.ts',
     // #30: k6 load-test entry (manual/nightly runbook, not a PR gate)
     'cli/loadtest': 'src/cli/loadtest.ts',
+    // CLI helpers exported as library subpaths (./cli/validate, ./cli/shared)
+    'cli/validate': 'src/cli/validate.ts',
+    'cli/shared': 'src/cli/shared.ts',
+    // --- Library surface (#114) -----------------------------------------
+    // dist/config.js — the `.` export (KnativeNextConfig type + helpers)
+    config: 'src/config.ts',
+    loader: 'src/loader.ts',
+    'adapters/next-adapter': 'src/adapters/next-adapter.ts',
+    'adapters/node-server': 'src/adapters/node-server.ts',
+    // cache-handler is plain JS (untyped) — bundled to dist, no .d.ts emitted
+    'adapters/cache-handler': 'src/adapters/cache-handler.js',
+    'adapters/otel-config': 'src/adapters/otel-config.ts',
+    'utils/logger': 'src/utils/logger.ts',
+  },
+  // Emit `.d.ts` declarations for the TS library entries so typed consumers
+  // (e.g. `import type { KnativeNextConfig } from '@knext/core'`) work. The
+  // cache-handler is plain untyped JS, so it is omitted from the DTS pass
+  // (TS6504) — its `exports` subpath is a bare `.js` with no `.d.ts`.
+  dts: {
+    entry: {
+      'cli/kn-next': 'src/cli/deploy.ts',
+      'cli/build': 'src/cli/build.ts',
+      'cli/cleanup': 'src/cli/cleanup.ts',
+      'cli/rollback': 'src/cli/rollback.ts',
+      'cli/preview': 'src/cli/preview.ts',
+      'cli/loadtest': 'src/cli/loadtest.ts',
+      'cli/validate': 'src/cli/validate.ts',
+      'cli/shared': 'src/cli/shared.ts',
+      config: 'src/config.ts',
+      loader: 'src/loader.ts',
+      'adapters/next-adapter': 'src/adapters/next-adapter.ts',
+      'adapters/node-server': 'src/adapters/node-server.ts',
+      'adapters/otel-config': 'src/adapters/otel-config.ts',
+      'utils/logger': 'src/utils/logger.ts',
+    },
   },
   format: ['esm'],
   platform: 'node',

--- a/packages/lib/LICENSE
+++ b/packages/lib/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 The knext Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,0 +1,31 @@
+# @knext/lib
+
+Shared runtime helpers for Next.js apps deployed with **knext** on Knative.
+
+Provides small, focused clients and utilities the knext runtime uses:
+
+- **Clients** — pooled Postgres, Redis, and object-storage (MinIO/S3) clients.
+- **Logger** — a structured (pino) logger.
+- **Health** — readiness/liveness health checks.
+
+## Install
+
+```bash
+npm i @knext/lib
+```
+
+## Usage
+
+```ts
+import { getDbPool, getMinioClient } from '@knext/lib/clients';
+import { logger } from '@knext/lib/logger';
+import { checkDeepHealth } from '@knext/lib/health';
+```
+
+## Documentation
+
+Full guides and configuration reference: <https://knext.dev>
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -13,6 +13,9 @@
     "build": "tsc",
     "dev": "tsc -w"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
Closes #114

## What changed
`@knext/core` advertised its entire library surface as raw `./src/*.ts` (main/types + every `exports` subpath), while `tsup` built only the CLI entries. A plain-Node consumer importing `@knext/core/adapter` or the `KnativeNextConfig` type was handed a `.ts` file Node cannot load.

- `tsup.config.ts`: added the library entries (config, loader, adapters/next-adapter, adapters/node-server, adapters/cache-handler, adapters/otel-config, utils/logger) + cli/validate, cli/shared; `dts` enabled (excludes the untyped `cache-handler.js`).
- `packages/kn-next/package.json`: main/module/types + every `exports` subpath repointed to `./dist/*`; `bin` unchanged; `files` trimmed to `["dist"]`.
- `packages/lib/package.json`: verified healthy (4 subpaths resolve; runtime deps declared) — no change.

Packaging-correctness only; no adapter/CLI/lib runtime logic changed.

## Tests
- New `packages/kn-next/src/__tests__/publish-surface.test.ts` (7 tests, RED→GREEN): asserts no `./src/*.ts` in the public surface, all subpaths resolve to built files, `bin` intact, typed subpaths emit `.d.ts`.
- Repo suite: 39 files / 300 tests passed.
- Manual: `pnpm pack` tarball contains every exports target and zero `src/` files; clean `npm i` in a fresh dir imported `@knext/core`, `@knext/core/adapter`, `@knext/core/adapters/otel-config` on plain Node; `kn-next --help` works.

Part of the Track-P package-deployment phase (PK1 → PK5 #116 → PK2 #115 → PK3 #117).