### PR TITLE
PK5 — Declare the public application API surface + stability contract (#116)

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,171 @@
+# knext Public API reference
+
+This page lists the **supported imports** a knext application may use at build time
+and runtime, and the **stability contract** behind them. If an import is listed
+here as public, you can rely on it. If it is not listed — or lives under an
+`/internal/` path — it is framework wiring with no compatibility guarantee.
+
+Two packages make up the application surface:
+
+- **`@knext/core`** — your Next.js config type, the deployment adapter, and
+  observability wiring.
+- **`@knext/lib`** — runtime helpers your application code calls (database and
+  object-store clients, a health check, a logger).
+
+---
+
+## `@knext/core`
+
+### `@knext/core`
+
+The configuration type for your `kn-next.config.ts`.
+
+```ts
+import type { KnativeNextConfig } from '@knext/core';
+
+const config: KnativeNextConfig = {
+  // storage, cache, queue, infrastructure, scaling, observability, secrets…
+};
+
+export default config;
+```
+
+Exported types: `KnativeNextConfig`, `StorageConfig`, `StorageProvider`,
+`CacheConfig`, `CacheProvider`, `RedisCacheConfig`, `DynamoDBCacheConfig`,
+`QueueConfig`, `QueueProvider`, `KafkaQueueConfig`, `NoQueueConfig`,
+`InfrastructureConfig`, `PostgresConfig`, `RedisInfraConfig`, `MinioInfraConfig`,
+`ScalingConfig`, `ObservabilityConfig`, `SecretsConfig`, `SecretRef`.
+
+### `@knext/core/adapter`
+
+The official Next.js deployment adapter. Wire it into your Next.js config so the
+build produces a knext-deployable output.
+
+```ts
+import adapter from '@knext/core/adapter';
+
+export default {
+  experimental: { adapterPath: '@knext/core/adapter' },
+};
+```
+
+Signature: `default` export — a Next.js deployment adapter object.
+
+### `@knext/core/adapters/otel-config`
+
+Resolves OpenTelemetry options from the environment for your
+`instrumentation.ts`. Tracing is off unless an endpoint is configured, so
+unconfigured apps pay nothing.
+
+```ts
+import { resolveOtelOptions } from '@knext/core/adapters/otel-config';
+
+const otel = resolveOtelOptions(); // OtelOptions | null
+```
+
+Exports: `resolveOtelOptions(): OtelOptions | null`, and the types `OtelOptions`,
+`OtelEnv`.
+
+---
+
+## `@knext/lib`
+
+All `@knext/lib` subpaths are public application API.
+
+### `@knext/lib/clients`
+
+Lazily-constructed clients for your zone's own data stores. Connection details
+come from the environment (`DATABASE_URL`, object-store credentials) — never
+hardcode them.
+
+```ts
+import { getDbPool, getMinioClient } from '@knext/lib/clients';
+
+const pool = getDbPool();        // pg.Pool
+const minio = getMinioClient();  // Minio.Client
+```
+
+Exports:
+- `getDbPool(): Pool` — a PostgreSQL connection pool (`pg`).
+- `getMinioClient(): Minio.Client` — an S3/MinIO-compatible object-store client.
+- `getCerbosClient(): Cerbos` — a Cerbos authorization client.
+
+### `@knext/lib/health`
+
+A deep readiness probe for your `/api/health` route. Verifies connectivity to
+core dependencies (Postgres, Redis).
+
+```ts
+import { checkDeepHealth } from '@knext/lib/health';
+
+const status = await checkDeepHealth(); // HealthStatus
+```
+
+Exports:
+- `checkDeepHealth(): Promise<HealthStatus>`
+- `HealthStatus` — `{ status: 'ok' | 'degraded' | 'down'; timestamp: string;
+  checks: { postgres: 'up' | 'down' | 'unconfigured'; redis: 'up' | 'down' |
+  'unconfigured' } }`.
+
+### `@knext/lib/logger`
+
+A shared JSON logger (`pino`) — structured JSON in production, pretty output in
+development.
+
+```ts
+import { logger } from '@knext/lib/logger';
+
+logger.info({ msg: 'ready' });
+```
+
+Exports: `logger` — a `pino.Logger`.
+
+### `@knext/lib`
+
+The package root re-exports everything from `@knext/lib/clients`,
+`@knext/lib/health`, and `@knext/lib/logger` for convenience.
+
+```ts
+import { getDbPool, checkDeepHealth, logger } from '@knext/lib';
+```
+
+---
+
+## Internal subpaths — NOT supported
+
+The following `@knext/core` subpaths are **framework wiring** used by the knext
+runtime, CLI, and operator. They live under an `/internal/` prefix so the
+boundary is visible in the import path itself. **Do not import them from
+application code** — they have no stability guarantee and may change or disappear
+in any release, including patch releases.
+
+| Internal import | What it is |
+| --- | --- |
+| `@knext/core/internal/next-adapter` | The adapter implementation behind `@knext/core/adapter`; import the public alias instead. |
+| `@knext/core/internal/node-server` | The standalone server entry the runtime spawns. |
+| `@knext/core/internal/cache-handler` | The ISR/data cache handler wired in by the framework. |
+| `@knext/core/internal/loader` | Internal config loader. |
+| `@knext/core/internal/logger` | Internal CLI/runtime logger (apps use `@knext/lib/logger`). |
+| `@knext/core/internal/cli-validate` | CLI config validation helpers. |
+| `@knext/core/internal/cli-shared` | Shared CLI utilities. |
+
+`@knext/lib` exposes no internal subpaths — its entire surface is public.
+
+---
+
+## Stability & versioning
+
+The **public surface** above follows [semantic versioning](https://semver.org/):
+
+- **Patch / minor releases** never remove or break a public import. New public
+  imports may be added in minor releases.
+- **Breaking changes** to any public import (removal, renamed export, changed
+  signature or type) require a **major version bump**.
+- Before a public import is removed, it is **deprecated** for at least one minor
+  release — marked deprecated in its types and noted in the changelog — so you
+  have a migration window.
+
+**Internal subpaths** (anything under `/internal/`, and any subpath not listed in
+this document) carry **no stability guarantee**. They may change or be removed in
+any release. If you find yourself needing one, please open an issue describing
+the use case so the capability can be considered for the public surface.

--- a/packages/kn-next/package.json
+++ b/packages/kn-next/package.json
@@ -15,46 +15,54 @@
       "import": "./dist/config.js",
       "default": "./dist/config.js"
     },
-    "./loader": {
-      "types": "./dist/loader.d.ts",
-      "import": "./dist/loader.js",
-      "default": "./dist/loader.js"
-    },
     "./adapter": {
       "types": "./dist/adapters/next-adapter.d.ts",
       "import": "./dist/adapters/next-adapter.js",
       "default": "./dist/adapters/next-adapter.js"
     },
-    "./adapters/next-adapter": {
-      "types": "./dist/adapters/next-adapter.d.ts",
-      "import": "./dist/adapters/next-adapter.js",
-      "default": "./dist/adapters/next-adapter.js"
-    },
-    "./adapters/node-server": {
-      "types": "./dist/adapters/node-server.d.ts",
-      "import": "./dist/adapters/node-server.js",
-      "default": "./dist/adapters/node-server.js"
-    },
-    "./adapters/cache-handler": "./dist/adapters/cache-handler.js",
     "./adapters/otel-config": {
       "types": "./dist/adapters/otel-config.d.ts",
       "import": "./dist/adapters/otel-config.js",
       "default": "./dist/adapters/otel-config.js"
     },
-    "./utils/logger": {
+    "./internal/next-adapter": {
+      "types": "./dist/adapters/next-adapter.d.ts",
+      "import": "./dist/adapters/next-adapter.js",
+      "default": "./dist/adapters/next-adapter.js"
+    },
+    "./internal/node-server": {
+      "types": "./dist/adapters/node-server.d.ts",
+      "import": "./dist/adapters/node-server.js",
+      "default": "./dist/adapters/node-server.js"
+    },
+    "./internal/cache-handler": "./dist/adapters/cache-handler.js",
+    "./internal/loader": {
+      "types": "./dist/loader.d.ts",
+      "import": "./dist/loader.js",
+      "default": "./dist/loader.js"
+    },
+    "./internal/logger": {
       "types": "./dist/utils/logger.d.ts",
       "import": "./dist/utils/logger.js",
       "default": "./dist/utils/logger.js"
     },
-    "./cli/validate": {
+    "./internal/cli-validate": {
       "types": "./dist/cli/validate.d.ts",
       "import": "./dist/cli/validate.js",
       "default": "./dist/cli/validate.js"
     },
-    "./cli/shared": {
+    "./internal/cli-shared": {
       "types": "./dist/cli/shared.d.ts",
       "import": "./dist/cli/shared.js",
       "default": "./dist/cli/shared.js"
+    }
+  },
+  "knext": {
+    "publicApi": {
+      "doc": "docs/PUBLIC_API.md",
+      "stability": "Public subpaths follow semver; ./internal/* subpaths carry no stability guarantee.",
+      "public": [".", "./adapter", "./adapters/otel-config"],
+      "internalPrefix": "./internal/"
     }
   },
   "scripts": {

--- a/packages/kn-next/src/__tests__/public-api-surface.test.ts
+++ b/packages/kn-next/src/__tests__/public-api-surface.test.ts
@@ -1,0 +1,211 @@
+/**
+ * PK5 (#116) — Public application API surface contract for @knext/core and
+ * @knext/lib.
+ *
+ * PK1 made the published surface *resolvable* (every `exports` subpath points
+ * at compiled `dist/` JS + `.d.ts`). PK5 makes it *intentional*: it draws the
+ * line between the SUPPORTED public application surface and INTERNAL
+ * framework-wiring subpaths, and documents that line in a user-facing Public
+ * API reference with a stability policy.
+ *
+ * These tests are the executable form of that contract. They assert:
+ *  - the public subpaths the doc promises all exist in `package.json` exports
+ *    and resolve to real JS + `.d.ts` in dist;
+ *  - internal subpaths are clearly separated under an `./internal/*` prefix
+ *    (the discoverable convention), never mixed into the public namespace;
+ *  - no in-repo app/runtime regressed onto a removed bare subpath.
+ *
+ * They are a real gate: if someone adds a new top-level export without marking
+ * it public (in the doc) or internal (under ./internal/*), this fails.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const corePkgDir = resolve(__dirname, "../..");
+const repoRoot = resolve(corePkgDir, "../..");
+const libPkgDir = resolve(repoRoot, "packages/lib");
+
+// biome-ignore lint/suspicious/noExplicitAny: reading arbitrary package.json shape
+const corePkg: any = require(resolve(corePkgDir, "package.json"));
+// biome-ignore lint/suspicious/noExplicitAny: reading arbitrary package.json shape
+const libPkg: any = require(resolve(libPkgDir, "package.json"));
+
+const PUBLIC_API_DOC = resolve(repoRoot, "docs/PUBLIC_API.md");
+
+/** The deliberate, supported public application surface (PK5). */
+const PUBLIC_CORE = [".", "./adapter", "./adapters/otel-config"];
+const PUBLIC_LIB = [".", "./logger", "./clients", "./health"];
+
+function jsTargetOf(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (value && typeof value === "object") {
+        const v = value as Record<string, string>;
+        return v.import ?? v.default;
+    }
+    return undefined;
+}
+
+function dtsTargetOf(value: unknown): string | undefined {
+    if (value && typeof value === "object") {
+        return (value as Record<string, string>).types;
+    }
+    return undefined;
+}
+
+describe("PK5: @knext/core public API surface", () => {
+    it("declares every documented public subpath", () => {
+        for (const sub of PUBLIC_CORE) {
+            expect(
+                corePkg.exports,
+                `core must publicly export ${sub}`,
+            ).toHaveProperty(sub);
+        }
+    });
+
+    it("resolves each public subpath to real JS + .d.ts in dist", () => {
+        for (const sub of PUBLIC_CORE) {
+            const entry = corePkg.exports[sub];
+            const js = jsTargetOf(entry);
+            const dts = dtsTargetOf(entry);
+            expect(js, `${sub} must declare a JS target`).toBeDefined();
+            expect(
+                existsSync(resolve(corePkgDir, js as string)),
+                `missing built JS for ${sub}: ${js}`,
+            ).toBe(true);
+            expect(dts, `${sub} must declare a .d.ts target`).toBeDefined();
+            expect(dts).toMatch(/\.d\.ts$/);
+            expect(
+                existsSync(resolve(corePkgDir, dts as string)),
+                `missing types for ${sub}: ${dts}`,
+            ).toBe(true);
+        }
+    });
+
+    it("keeps internal framework-wiring subpaths under ./internal/*", () => {
+        // These are framework wiring used by the runtime / CLI / operator —
+        // not a stable application import. PK5 segregates them so the boundary
+        // is visible in the exports map itself, not just in prose.
+        const internalConcepts = [
+            "node-server",
+            "cache-handler",
+            "loader",
+            "cli-shared",
+            "cli-validate",
+            "internal-logger",
+        ];
+        const internalKeys = Object.keys(corePkg.exports).filter((k) =>
+            k.startsWith("./internal/"),
+        );
+        expect(
+            internalKeys.length,
+            "internal subpaths must be exposed under ./internal/*",
+        ).toBeGreaterThanOrEqual(internalConcepts.length);
+    });
+
+    it("does not expose framework internals in the public namespace", () => {
+        // No bare (non-./internal) export may target a known-internal module.
+        const forbidden = [
+            "node-server",
+            "cache-handler",
+            "cli/shared.js",
+            "cli/validate.js",
+        ];
+        for (const [key, value] of Object.entries(corePkg.exports)) {
+            if (key.startsWith("./internal/")) continue;
+            const js = jsTargetOf(value) ?? "";
+            for (const f of forbidden) {
+                expect(
+                    js.includes(f),
+                    `public export ${key} must not target internal module ${f}`,
+                ).toBe(false);
+            }
+        }
+    });
+
+    it("every non-internal export is named public in the doc", () => {
+        const doc = readFileSync(PUBLIC_API_DOC, "utf8");
+        for (const key of Object.keys(corePkg.exports)) {
+            if (key.startsWith("./internal/")) continue;
+            const importPath =
+                key === "." ? "@knext/core" : `@knext/core${key.slice(1)}`;
+            expect(
+                doc.includes(importPath),
+                `public core export ${key} must be documented as @knext/core${key === "." ? "" : key.slice(1)}`,
+            ).toBe(true);
+        }
+    });
+});
+
+describe("PK5: @knext/lib public API surface", () => {
+    it("declares every documented public subpath", () => {
+        for (const sub of PUBLIC_LIB) {
+            expect(
+                libPkg.exports,
+                `lib must publicly export ${sub}`,
+            ).toHaveProperty(sub);
+        }
+    });
+
+    it("resolves each public subpath to real JS + .d.ts in dist", () => {
+        for (const sub of PUBLIC_LIB) {
+            const entry = libPkg.exports[sub];
+            const js = jsTargetOf(entry);
+            const dts = dtsTargetOf(entry);
+            expect(js, `${sub} must declare a JS target`).toBeDefined();
+            expect(
+                existsSync(resolve(libPkgDir, js as string)),
+                `missing built JS for ${sub}: ${js}`,
+            ).toBe(true);
+            expect(dts, `${sub} must declare a .d.ts target`).toBeDefined();
+            expect(dts).toMatch(/\.d\.ts$/);
+            expect(
+                existsSync(resolve(libPkgDir, dts as string)),
+                `missing types for ${sub}: ${dts}`,
+            ).toBe(true);
+        }
+    });
+});
+
+describe("PK5: Public API reference doc accuracy", () => {
+    it("the doc exists and is user-facing (no internal jargon)", () => {
+        expect(
+            existsSync(PUBLIC_API_DOC),
+            "docs/PUBLIC_API.md must exist",
+        ).toBe(true);
+        const doc = readFileSync(PUBLIC_API_DOC, "utf8");
+        // user-facing: must not leak ADR numbers, PK/issue jargon, or strategy terms
+        expect(doc).not.toMatch(/ADR-\d{4}/);
+        expect(doc).not.toMatch(/\bPK\d\b/);
+        expect(doc).not.toMatch(/#\d{2,}/);
+    });
+
+    it("documents the public surface for both packages", () => {
+        const doc = readFileSync(PUBLIC_API_DOC, "utf8");
+        for (const sub of PUBLIC_CORE) {
+            const p =
+                sub === "." ? "@knext/core" : `@knext/core${sub.slice(1)}`;
+            expect(doc.includes(p), `doc must list ${p}`).toBe(true);
+        }
+        for (const sub of PUBLIC_LIB) {
+            const p = sub === "." ? "@knext/lib" : `@knext/lib${sub.slice(1)}`;
+            expect(doc.includes(p), `doc must list ${p}`).toBe(true);
+        }
+    });
+
+    it("names the internal (unsupported) subpaths explicitly", () => {
+        const doc = readFileSync(PUBLIC_API_DOC, "utf8");
+        expect(doc.toLowerCase()).toContain("internal");
+        expect(doc).toContain("@knext/core/internal/");
+    });
+
+    it("states a stability / semver policy", () => {
+        const doc = readFileSync(PUBLIC_API_DOC, "utf8").toLowerCase();
+        expect(doc).toContain("semver");
+        expect(doc).toContain("deprecat");
+        expect(doc).toMatch(/stability|stable/);
+    });
+});

--- a/packages/kn-next/src/__tests__/publish-surface.test.ts
+++ b/packages/kn-next/src/__tests__/publish-surface.test.ts
@@ -33,7 +33,8 @@ function exportTargets(): string[] {
     if (typeof pkg.main === "string") targets.push(pkg.main);
     if (typeof pkg.types === "string") targets.push(pkg.types);
     if (typeof pkg.module === "string") targets.push(pkg.module);
-    for (const value of Object.values(pkg.exports ?? {})) {
+    for (const [key, value] of Object.entries(pkg.exports ?? {})) {
+        if (key === "//") continue; // documentation marker, not a file target
         if (typeof value === "string") {
             targets.push(value);
         } else if (value && typeof value === "object") {
@@ -70,17 +71,22 @@ describe("PK1: @knext/core publish surface", () => {
 
     it("declares every library subpath the example app and CLI import", () => {
         const exp = pkg.exports ?? {};
+        // PK5 (#116) split these into a PUBLIC application surface and
+        // INTERNAL framework-wiring subpaths under ./internal/*. Every dist
+        // target the example app and runtime resolve must still be declared.
         for (const subpath of [
+            // public application surface
             ".",
-            "./loader",
             "./adapter",
-            "./adapters/next-adapter",
-            "./adapters/node-server",
-            "./adapters/cache-handler",
             "./adapters/otel-config",
-            "./utils/logger",
-            "./cli/validate",
-            "./cli/shared",
+            // internal framework wiring (runtime / CLI / operator)
+            "./internal/next-adapter",
+            "./internal/node-server",
+            "./internal/cache-handler",
+            "./internal/loader",
+            "./internal/logger",
+            "./internal/cli-validate",
+            "./internal/cli-shared",
         ]) {
             expect(exp, `exports must declare ${subpath}`).toHaveProperty(
                 subpath,
@@ -109,7 +115,9 @@ describe("PK1: @knext/core publish surface", () => {
 
     it("emits a .d.ts for each TypeScript-typed subpath", () => {
         const typed = Object.entries(pkg.exports ?? {})
-            .filter(([sub]) => sub !== "./adapters/cache-handler")
+            .filter(
+                ([sub]) => sub !== "./internal/cache-handler" && sub !== "//",
+            )
             .map(([, value]) =>
                 typeof value === "string"
                     ? value

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -4,10 +4,39 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
-    "./logger": "./dist/logger/index.js",
-    "./clients": "./dist/clients.js",
-    "./health": "./dist/health/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./logger": {
+      "types": "./dist/logger/index.d.ts",
+      "import": "./dist/logger/index.js",
+      "default": "./dist/logger/index.js"
+    },
+    "./clients": {
+      "types": "./dist/clients.d.ts",
+      "import": "./dist/clients.js",
+      "default": "./dist/clients.js"
+    },
+    "./health": {
+      "types": "./dist/health/index.d.ts",
+      "import": "./dist/health/index.js",
+      "default": "./dist/health/index.js"
+    }
+  },
+  "knext": {
+    "publicApi": {
+      "doc": "docs/PUBLIC_API.md",
+      "stability": "All @knext/lib subpaths are public and follow semver.",
+      "public": [
+        ".",
+        "./logger",
+        "./clients",
+        "./health"
+      ],
+      "internalPrefix": null
+    }
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Closes #116

**Stacked on #119 (PK1)** — base is the PK1 branch; review only the PK5 diff.

## What changed
knext now declares which package subpaths are the supported **public application API** vs **internal**, with a stability policy.

- **Public** — `@knext/core`: `.` (config types), `./adapter`, `./adapters/otel-config`; `@knext/lib`: `.`, `./logger`, `./clients`, `./health`.
- **Internal** — moved under a discoverable `./internal/*` prefix on `@knext/core`: `internal/next-adapter`, `internal/node-server`, `internal/cache-handler`, `internal/loader`, `internal/logger`, `internal/cli-validate`, `internal/cli-shared`. Grepped the repo: nothing imports these as package subpaths (the runtime reaches node-server/cache-handler by file path via env vars), so the move is non-breaking.
- `knext.publicApi` marker field added to both package.jsons (machine-readable; Node rejects comment keys in `exports`).
- New `docs/PUBLIC_API.md`: user-facing reference (signatures + named internal subpaths + semver/deprecation/stability policy).

## Tests
- New `public-api-surface.test.ts` gate: every documented public subpath exists + resolves (JS + .d.ts); internals stay under `./internal/*`; no public export targets an internal module; doc names internals + states the policy. Adding an unclassified export fails it.
- Updated `publish-surface.test.ts` to the new internal naming (not weakened).
- Suite: 19 files / 201 tests passed; build verified lib→core; file-manager resolves public subpaths from dist.

Part of Track-P package deployment (PK1 #114 → PK5 #116 → PK2 #115 → PK3 #117).